### PR TITLE
Bug fix

### DIFF
--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/GwtApp.gwt.xml
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/GwtApp.gwt.xml
@@ -7,7 +7,7 @@
   <inherits name='com.google.gwt.user.User'/>
   <!-- Logging -->
   <inherits name="com.google.gwt.logging.Logging"/>
-  <set-property name="gwt.logging.enabled" value="FALSE"/>
+  <set-property name="gwt.logging.enabled" value="TRUE"/>
   <!-- Guava Collections -->
   <inherits name='com.google.common.collect.Collect'/>
   <!-- Sophisticated visualisations -->

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/navigator/view/DatasourceView.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/navigator/view/DatasourceView.java
@@ -167,9 +167,11 @@ public class DatasourceView extends ViewImpl implements DatasourcePresenter.Disp
 
   @Override
   public void afterRenderRows() {
+    boolean enableItem = table.getRowCount() > 0;
     pager.setVisible(table.getRowCount() > NavigatorView.PAGE_SIZE);
-    toolbar.setExportDataItemEnabled(table.getRowCount() > 0);
-    toolbar.setCopyDataItemEnabled(table.getRowCount() > 0);
+    toolbar.setExportVariableDictionaryItemEnabled(enableItem);
+    toolbar.setExportDataItemEnabled(enableItem);
+    toolbar.setCopyDataItemEnabled(enableItem);
     table.setEmptyTableWidget(noTables);
   }
 
@@ -301,7 +303,7 @@ public class DatasourceView extends ViewImpl implements DatasourcePresenter.Disp
 
   @Override
   public HasAuthorization getExcelDownloadAuthorizer() {
-    return new MenuItemAuthorizer(toolbar.getExcelDownloadItem());
+    return new MenuItemAuthorizer(toolbar.getExportVariableDictionaryItem());
   }
 
   @Override

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/navigator/view/NavigatorMenuBar.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/navigator/view/NavigatorMenuBar.java
@@ -29,7 +29,7 @@ public class NavigatorMenuBar extends MenuBar {
 
   private MenuBar toolsMenu;
 
-  private MenuItem excelDownloadItem;
+  private MenuItem exportVariableDictionaryItem;
 
   private MenuItem importDataItem;
 
@@ -143,16 +143,16 @@ public class NavigatorMenuBar extends MenuBar {
   }
 
   public void setExcelDownloadCommand(Command cmd) {
-    if(excelDownloadItem == null) {
-      excelDownloadItem = new MenuItem(translations.exportToExcelTitle(), cmd);
-      getToolsMenu().addItem(excelDownloadItem);
+    if(exportVariableDictionaryItem == null) {
+      exportVariableDictionaryItem = new MenuItem(translations.exportToExcelTitle(), cmd);
+      getToolsMenu().addItem(exportVariableDictionaryItem);
     } else {
-      excelDownloadItem.setCommand(cmd);
+      exportVariableDictionaryItem.setCommand(cmd);
     }
   }
 
-  public MenuItem getExcelDownloadItem() {
-    return excelDownloadItem;
+  public MenuItem getExportVariableDictionaryItem() {
+    return exportVariableDictionaryItem;
   }
 
   public void setImportDataCommand(Command cmd) {
@@ -266,6 +266,12 @@ public class NavigatorMenuBar extends MenuBar {
 
   public MenuItem getEditItem() {
     return editItem;
+  }
+
+  public void setExportVariableDictionaryItemEnabled(boolean enabled) {
+    if(exportVariableDictionaryItem != null) {
+      exportVariableDictionaryItem.setEnabled(enabled);
+    }
   }
 
   public void setExportDataItemEnabled(boolean enabled) {

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/navigator/view/TableView.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/navigator/view/TableView.java
@@ -198,8 +198,10 @@ public class TableView extends ViewImpl implements TablePresenter.Display {
 
   @Override
   public void afterRenderRows() {
+    boolean enableItem = dataProvider.getList().size() > 0;
     pager.setVisible(dataProvider.getList().size() > NavigatorView.PAGE_SIZE);
-    toolbar.setExportDataItemEnabled(dataProvider.getList().size() > 0);
+    toolbar.setExportVariableDictionaryItemEnabled(enableItem);
+    toolbar.setExportDataItemEnabled(enableItem);
     table.setEmptyTableWidget(noVariables);
   }
 
@@ -396,7 +398,7 @@ public class TableView extends ViewImpl implements TablePresenter.Display {
 
   @Override
   public HasAuthorization getExcelDownloadAuthorizer() {
-    return new MenuItemAuthorizer(toolbar.getExcelDownloadItem());
+    return new MenuItemAuthorizer(toolbar.getExportVariableDictionaryItem());
   }
 
   @Override


### PR DESCRIPTION
Renamed the button 'Export Variable Dictionary' and disabled it when a datasource, table or a view was empty
