### PR TITLE
OPAL-1726 - set variable index to ZERO when indexing opal-variables

### DIFF
--- a/opal-search/src/main/java/org/obiba/opal/search/es/EsVariablesIndexManager.java
+++ b/opal-search/src/main/java/org/obiba/opal/search/es/EsVariablesIndexManager.java
@@ -91,7 +91,7 @@ public class EsVariablesIndexManager extends EsIndexManager implements Variables
     protected void index() {
       BulkRequestBuilder bulkRequest = esProvider.getClient().prepareBulk();
 
-      int tableIndex = 1;
+      int tableIndex = 0;
       for(Variable variable : valueTable.getVariables()) {
         bulkRequest = indexVariable(variable, bulkRequest, tableIndex++);
       }

--- a/opal-search/src/main/java/org/obiba/opal/search/service/OpalSearchService.java
+++ b/opal-search/src/main/java/org/obiba/opal/search/service/OpalSearchService.java
@@ -59,8 +59,6 @@ public class OpalSearchService implements Service, ElasticSearchProvider {
     if(!isRunning() && esConfig.isEnabled()) {
       esNode = NodeBuilder.nodeBuilder().client(true) //
           .settings(ImmutableSettings.settingsBuilder() //
-              .put("http.enabled", false) //
-              .put("discovery.zen.ping.multicast.enabled", false) //
               .classLoader(OpalSearchService.class.getClassLoader())
               .loadFromClasspath(DEFAULT_SETTINGS_RESOURCE) //
               .loadFromSource(esConfig.getEsSettings())) //

--- a/opal-search/src/main/resources/org/obiba/opal/search/service/default-settings.yml
+++ b/opal-search/src/main/resources/org/obiba/opal/search/service/default-settings.yml
@@ -1,3 +1,5 @@
+http.enabled: true
+discovery.zen.ping.multicast.enabled: false
 index:
     analysis:
           analyzer:


### PR DESCRIPTION
Also, placed all settings in the default-settings.yml file
