### PR TITLE
Added an extra test for validating that the index is up-to-date

### DIFF
--- a/opal-search/src/main/java/org/obiba/opal/search/es/EsIndexManager.java
+++ b/opal-search/src/main/java/org/obiba/opal/search/es/EsIndexManager.java
@@ -113,7 +113,7 @@ abstract class EsIndexManager implements IndexManager, ValueTableUpdateListener 
 
   @Override
   public boolean isReady() {
-    return esConfig.getConfig().isEnabled();
+    return opalSearchService.isEnabled();
   }
 
   @Override

--- a/opal-search/src/main/java/org/obiba/opal/web/search/TableVariablesSearchResource.java
+++ b/opal-search/src/main/java/org/obiba/opal/web/search/TableVariablesSearchResource.java
@@ -64,7 +64,7 @@ public class TableVariablesSearchResource extends AbstractVariablesSearchResourc
       @QueryParam("sortField") String sortField, @QueryParam("sortDir") String sortDir) {
 
     try {
-      if(!searchServiceAvailable()) return Response.status(Response.Status.SERVICE_UNAVAILABLE).build();
+      if(!canQueryEsIndex()) return Response.status(Response.Status.SERVICE_UNAVAILABLE).build();
       if(!indexManager.hasIndex(getValueTable())) return Response.status(Response.Status.NOT_FOUND).build();
       QuerySearchJsonBuilder jsonBuiler = //
           buildQuerySearch(query, offset, limit, fields, sortField, sortDir);
@@ -97,6 +97,10 @@ public class TableVariablesSearchResource extends AbstractVariablesSearchResourc
   //
   // Private methods
   //
+
+  private boolean canQueryEsIndex() {
+    return searchServiceAvailable() && indexManager.isIndexUpToDate(getValueTable());
+  }
 
   private ValueTable getValueTable() {
     return MagmaEngine.get().getDatasource(datasource).getValueTable(table);


### PR DESCRIPTION
Two things modified:
- As a first step refactoring in EsIndexManager.java, made sure the isReady() uses the same code as OpalSearchService.isEnabled(). May be we should only use one method unless it is necessary to leave this test available in this class
- In order for the client code to fall back to Magma variable searching, added the test that the table's index is up-to-date. Return code is 503, may be we need two error codes for service available and index not up-to-date?
