### PR TITLE
OPAL-2009

### DIFF
--- a/opal-core-ws/src/main/java/org/obiba/opal/web/system/database/DatabaseResource.java
+++ b/opal-core-ws/src/main/java/org/obiba/opal/web/system/database/DatabaseResource.java
@@ -112,7 +112,7 @@ public class DatabaseResource {
   }
 
   private Response testMongoConnection() {
-    Ws.ClientErrorDto error = ClientErrorDtos.getErrorMessage(SERVICE_UNAVAILABLE, "DatabaseConnectionFailed").build();
+    Ws.ClientErrorDto error = null;
     try {
       MongoDbDatabase database = (MongoDbDatabase) getDatabase();
       MongoDBDatasourceFactory datasourceFactory = database.createMongoDBDatasourceFactory("_test");
@@ -120,6 +120,8 @@ public class DatabaseResource {
       if(dbs.contains(datasourceFactory.getMongoDbDatabaseName())) {
         return Response.ok().build();
       }
+      error = ClientErrorDtos.getErrorMessage(SERVICE_UNAVAILABLE, "FailedToConnectToDatabase", database.getName())
+          .build();
     } catch(RuntimeException e) {
       error = ClientErrorDtos.getErrorMessage(SERVICE_UNAVAILABLE, "DatabaseConnectionFailed", e);
     }

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/i18n/Translations.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/i18n/Translations.java
@@ -399,6 +399,7 @@ public interface Translations extends Constants {
       "DatabaseAlreadyExists", "A database with this name already exists.",//
       "DatabaseConnectionOk", "Connection successful.",//
       "DatabaseConnectionFailed", "Failed to connect: {0}.",//
+      "FailedToConnectToDatabase", "Failed to connect to database '{0}'.",//
       "DatabaseIsNotEditable", "Database is used by a Datasource and is not editable",//
       "CannotFindDatabase", "Cannot find database named {0}",//
       "NameIsRequired", "A name is required.",//

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/rest/client/DefaultResourceRequestBuilder.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/rest/client/DefaultResourceRequestBuilder.java
@@ -100,6 +100,7 @@ public class DefaultResourceRequestBuilder<T extends JavaScriptObject> implement
 
   @Override
   public DefaultResourceRequestBuilder<T> withCallback(int code, ResponseCodeCallback callback) {
+    accept(RESOURCE_MEDIA_TYPE);
     if(codes == null) {
       codes = new ResponseCodeCallback[Response.SC_HTTP_VERSION_NOT_SUPPORTED];
     }
@@ -109,6 +110,7 @@ public class DefaultResourceRequestBuilder<T extends JavaScriptObject> implement
 
   @Override
   public ResourceRequestBuilder<T> withCallback(ResponseCodeCallback callback, int... responseCodes) {
+    accept(RESOURCE_MEDIA_TYPE);
     if(codes == null) {
       codes = new ResponseCodeCallback[Response.SC_HTTP_VERSION_NOT_SUPPORTED];
     }


### PR DESCRIPTION
added a more specific error message with the name of the DB
Made sure DefaultResourceRequestBuilder.withCallback() adds the proper ACCEPT header, ie., Protobuf+JSON
