### PR TITLE
OPAL-2029

### DIFF
--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/presenter/VariablePresenter.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/presenter/VariablePresenter.java
@@ -125,7 +125,7 @@ public class VariablePresenter extends PresenterWidget<VariablePresenter.Display
 
   @Override
   public void onVariableSelectionChanged(VariableSelectionChangeEvent event) {
-    resetView();
+    resetView(event.getTable());
 
     if(event.hasTable()) {
       updateDisplay(event.getTable(), event.getSelection(), event.getPrevious(), event.getNext());
@@ -249,6 +249,7 @@ public class VariablePresenter extends PresenterWidget<VariablePresenter.Display
     scriptEditorPresenter.setValueEntityType(variable.getValueType());
   }
 
+  @SuppressWarnings("MethodOnlyUsedFromInnerClass")
   private void updateDerivedVariableByCommitInfo(VcsCommitInfoDto commitInfo) {
     getView().goToEditScript();
     scriptEditorPresenter.setScript(commitInfo.getBlob());
@@ -417,8 +418,17 @@ public class VariablePresenter extends PresenterWidget<VariablePresenter.Display
     propertiesEditorPresenter.initialize(variable, table);
   }
 
-  private void resetView() {
+  private void resetView(TableDto tableDto) {
     getView().backToViewScript();
+    if (tableChanged(tableDto)) {
+      getView().resetTabs();
+    }
+  }
+
+  private boolean tableChanged(TableDto tableDto) {
+    String curTableName = table != null ? table.getName() : "";
+    String newTableName = tableDto != null ? tableDto.getName() : "";
+    return !curTableName.equals(newTableName);
   }
 
   //
@@ -535,7 +545,7 @@ public class VariablePresenter extends PresenterWidget<VariablePresenter.Display
     @Override
     public void onResponseCode(Request request, Response response) {
       if(response.getStatusCode() == SC_OK) {
-        UpdateVariableCallbackHandler updateVariableCallbackHandler = new UpdateVariableCallbackHandler(newVariable);
+        ResponseCodeCallback updateVariableCallbackHandler = new UpdateVariableCallbackHandler(newVariable);
 
         String uri = UriBuilder.create().segment("datasource", "{}", "view", "{}", "variable", "{}")
             .query("comment", getView().getComment())
@@ -637,5 +647,7 @@ public class VariablePresenter extends PresenterWidget<VariablePresenter.Display
     HasAuthorization getEditAuthorizer();
 
     void setDeriveFromMenuVisibility(boolean visible);
+
+    void resetTabs();
   }
 }

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/view/ContinuousSummaryView.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/view/ContinuousSummaryView.java
@@ -31,7 +31,7 @@ import com.google.gwt.user.client.ui.Widget;
  */
 public class ContinuousSummaryView extends Composite {
 
-  interface ContinuousSummaryViewUiBinder extends UiBinder<Widget, ContinuousSummaryView> {}
+  private interface ContinuousSummaryViewUiBinder extends UiBinder<Widget, ContinuousSummaryView> {}
 
   private static final ContinuousSummaryViewUiBinder uiBinder = GWT.create(ContinuousSummaryViewUiBinder.class);
 
@@ -46,9 +46,9 @@ public class ContinuousSummaryView extends Composite {
   @UiField
   SimplePanel normalProbability;
 
-  HistogramChartFactory histogram;
+  private HistogramChartFactory histogram;
 
-  NormalProbabilityChartFactory qqPlot;
+  private NormalProbabilityChartFactory qqPlot;
 
   public ContinuousSummaryView(ContinuousSummaryDto continuous) {
     initWidget(uiBinder.createAndBindUi(this));
@@ -103,10 +103,12 @@ public class ContinuousSummaryView extends Composite {
   protected void onLoad() {
     super.onLoad();
     if(histogram != null) {
+      histogramPanel.clear();
       histogramPanel
           .add(histogram.createChart(translations.statsMap().get("HISTOGRAM"), translations.statsMap().get("DENSITY")));
     }
     if(qqPlot != null) {
+      normalProbability.clear();
       normalProbability.add(qqPlot.createChart(translations.statsMap().get("NORMAL_PROB"),
           translations.statsMap().get("THEORETHICAL_QUANTILES"), translations.statsMap().get("SAMPLE_QUANTILES")));
     }

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/view/VariableView.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/view/VariableView.java
@@ -412,6 +412,12 @@ public class VariableView extends ViewWithUiHandlers<VariableUiHandlers> impleme
   }
 
   @Override
+  public void resetTabs() {
+    TabPanelHelper.setTabActive(tabPanel, tabPanel.getSelectedTab(), false);
+    TabPanelHelper.setTabActive(tabPanel, DICTIONARY_TAB_INDEX, true);
+  }
+
+  @Override
   public HasAuthorization getEditAuthorizer() {
     return new CompositeAuthorizer(new WidgetAuthorizer(remove), new WidgetAuthorizer(editScript));
   }
@@ -431,8 +437,6 @@ public class VariableView extends ViewWithUiHandlers<VariableUiHandlers> impleme
   @Override
   public void setDerivedVariable(boolean derived, String value) {
     TabPanelHelper.setTabVisible(tabPanel, SCRIPT_TAB_INDEX, derived);
-    TabPanelHelper.setTabActive(tabPanel, SCRIPT_TAB_INDEX, derived);
-    TabPanelHelper.setTabActive(tabPanel, DICTIONARY_TAB_INDEX, !derived);
     scriptHeaderPanel.setVisible(derived);
     noScript.setVisible(derived && value.isEmpty());
     script.setVisible(derived && !value.isEmpty());


### PR DESCRIPTION
Reset the VariableView's tabs when tables changed. 
Fixed a new bug when navigating thru variable summaries.
