### PR TITLE
OPAL-2027

### DIFF
--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/presenter/TablePresenter.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/presenter/TablePresenter.java
@@ -22,8 +22,6 @@ import org.obiba.opal.web.gwt.app.client.js.JsArrays;
 import org.obiba.opal.web.gwt.app.client.magma.configureview.event.ViewSavedEvent;
 import org.obiba.opal.web.gwt.app.client.magma.configureview.presenter.ConfigureViewStepPresenter;
 import org.obiba.opal.web.gwt.app.client.magma.copydata.presenter.DataCopyPresenter;
-import org.obiba.opal.web.gwt.app.client.magma.event.DatasourceSelectionChangeEvent;
-import org.obiba.opal.web.gwt.app.client.magma.event.DatasourceUpdatedEvent;
 import org.obiba.opal.web.gwt.app.client.magma.event.SiblingVariableSelectionEvent;
 import org.obiba.opal.web.gwt.app.client.magma.event.TableIndexStatusRefreshEvent;
 import org.obiba.opal.web.gwt.app.client.magma.event.TableSelectionChangeEvent;

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/presenter/VariablePresenter.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/presenter/VariablePresenter.java
@@ -22,7 +22,6 @@ import org.obiba.opal.web.gwt.app.client.js.JsArrays;
 import org.obiba.opal.web.gwt.app.client.magma.configureview.event.ViewSavedEvent;
 import org.obiba.opal.web.gwt.app.client.magma.derive.helper.VariableDuplicationHelper;
 import org.obiba.opal.web.gwt.app.client.magma.derive.presenter.DeriveVariablePresenter;
-import org.obiba.opal.web.gwt.app.client.magma.event.DatasourceSelectionChangeEvent;
 import org.obiba.opal.web.gwt.app.client.magma.event.SiblingVariableSelectionEvent;
 import org.obiba.opal.web.gwt.app.client.magma.event.SiblingVariableSelectionEvent.Direction;
 import org.obiba.opal.web.gwt.app.client.magma.event.SummaryRequiredEvent;

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/view/VariableView.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/view/VariableView.java
@@ -133,12 +133,6 @@ public class VariableView extends ViewWithUiHandlers<VariableUiHandlers> impleme
   CodeBlock script;
 
   @UiField
-  InlineLabel noScript;
-
-  @UiField
-  InlineLabel notDerived;
-
-  @UiField
   Button previous;
 
   @UiField
@@ -438,7 +432,6 @@ public class VariableView extends ViewWithUiHandlers<VariableUiHandlers> impleme
   public void setDerivedVariable(boolean derived, String value) {
     TabPanelHelper.setTabVisible(tabPanel, SCRIPT_TAB_INDEX, derived);
     scriptHeaderPanel.setVisible(derived);
-    noScript.setVisible(derived && value.isEmpty());
     script.setVisible(derived && !value.isEmpty());
     script.setText(value);
   }

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/view/VariableView.ui.xml
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/view/VariableView.ui.xml
@@ -147,9 +147,6 @@
 
       <b:Tab heading="Script" ui:field="scriptTab">
         <g:FlowPanel ui:field="scriptHeaderPanel">
-          <b2:InlineLabel ui:field="notDerived">
-            <ui:msg description="Not Derived Variable label">Not a Derived Variable</ui:msg>
-          </b2:InlineLabel>
           <g:FlowPanel addStyleNames="clearfix">
             <b:NavLink icon="CHEVRON_LEFT" addStyleNames="pull-left" ui:field="backToScript">
               <ui:msg description="Script label">Script</ui:msg>
@@ -172,9 +169,6 @@
         <o:TabDeckPanel ui:field="scriptNavPanel" animationEnabled="false" addStyleNames="top-margin">
           <g:FlowPanel>
             <g:FlowPanel>
-              <b2:InlineLabel ui:field="noScript">
-                <ui:msg description="No Script label">No Script</ui:msg>
-              </b2:InlineLabel>
               <b:CodeBlock ui:field="script"></b:CodeBlock>
             </g:FlowPanel>
           </g:FlowPanel>


### PR DESCRIPTION
made the control invisible when viewing derived variable. 
Removed the noScript control.
