### PR TITLE
Bug fix

### DIFF
--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/fs/presenter/FileExplorerPresenter.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/fs/presenter/FileExplorerPresenter.java
@@ -83,6 +83,10 @@ public class FileExplorerPresenter extends PresenterWidget<FileExplorerPresenter
     filePlacesPresenter.showProject(project);
   }
 
+  public void reset() {
+    folderDetailsPresenter.setCurrentFolder(null);
+  }
+
   @Override
   protected void onBind() {
     super.onBind();

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/project/presenter/ProjectPresenter.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/project/presenter/ProjectPresenter.java
@@ -165,6 +165,7 @@ public class ProjectPresenter extends Presenter<ProjectPresenter.Display, Projec
       getView().setTabData(tab.ordinal(), tab == Display.ProjectTab.TABLES ? validatePath(projectName,
           request.getParameter(ParameterTokens.TOKEN_PATH, null)) : null);
     } else {
+      if(fileExplorerPresenter != null) fileExplorerPresenter.reset();
       getView().clearTabsData();
     }
 


### PR DESCRIPTION
When changing projects, remove the FileExplorer current folder so that the request won't carry the folder path in the url (PlaceRequest).
