### PR TITLE
OPAL-2330: Set the matcherCallback function of Typeahead to always retur...

### DIFF
--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/ui/SuggestListBox.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/ui/SuggestListBox.java
@@ -128,6 +128,15 @@ public class SuggestListBox extends FocusPanel {
     textBox = new TextBox();
     aheadBox = new Typeahead(oracle);
     aheadBox.add(textBox);
+
+    // Set matchercallback to always return true so TypeHead does not filter values furthermore
+    aheadBox.setMatcherCallback(new Typeahead.MatcherCallback() {
+      @Override
+      public boolean compareQueryToItem(String query, String item) {
+        return true;
+      }
+    });
+
     content.add(aheadBox);
     addSuggestBoxHandlers();
   }


### PR DESCRIPTION
...n true so the results are not filtered upon reception (they have already been filtered by the ES query)
