### PR TITLE
OPAL-2361: Catch magma exception when missing category cannot be cast to...

### DIFF
--- a/opal-core-api/src/main/java/org/obiba/opal/core/magma/math/ContinuousVariableSummary.java
+++ b/opal-core-api/src/main/java/org/obiba/opal/core/magma/math/ContinuousVariableSummary.java
@@ -22,6 +22,7 @@ import org.apache.commons.math3.distribution.NormalDistribution;
 import org.apache.commons.math3.distribution.RealDistribution;
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
 import org.obiba.magma.Category;
+import org.obiba.magma.MagmaRuntimeException;
 import org.obiba.magma.Value;
 import org.obiba.magma.ValueSource;
 import org.obiba.magma.ValueTable;
@@ -93,7 +94,13 @@ public class ContinuousVariableSummary extends AbstractVariableSummary implement
     if(variable.hasCategories()) {
       for(Category c : variable.getCategories()) {
         if(c.isMissing()) {
-          missing.add(variable.getValueType().valueOf(c.getName()));
+          try {
+            missing.add(variable.getValueType().valueOf(c.getName()));
+          } catch(MagmaRuntimeException e) {
+            // When valueOf expects a integer but get a string category, do not crash
+            log.warn("Variable {}, Category {}, ValueType ({}): {}", variable.getName(), c.getName(),
+                variable.getValueType().getName(), e.getMessage());
+          }
         }
       }
     }


### PR DESCRIPTION
... a continuous valueType

Because, Magma has its own logic to compute the valueOf Double and Integer, I think its preferrable to catch the exception than to copy and apply the same logic. Here is what Magma does :

DecimalType.java (normalize replaces the ',' char with '.')

``` java
try {
      return Factory.newValue(this, Double.valueOf(normalize(string)));
    } catch(NumberFormatException e) {
      throw new MagmaRuntimeException("Not a decimal value: " + string, e);
    }
```

IntegerType.java (normalize trims the string)

``` java
try {
      return Strings.isNullOrEmpty(string) ? nullValue() : Factory.newValue(this, Long.valueOf(normalize(string)));
    } catch(NumberFormatException e) {
      throw new MagmaRuntimeException("Not a integer value: " + string, e);
    }
```
