### PR TITLE
White colors for icons in input-append and input-prepend and dropdown arrow

### DIFF
--- a/opal-gwt-client/src/main/resources/org/obiba/opal/web/gwt/app/public/less/opal.less
+++ b/opal-gwt-client/src/main/resources/org/obiba/opal/web/gwt/app/public/less/opal.less
@@ -164,6 +164,8 @@ th input[type="checkbox"], td input[type="checkbox"] {
 
 .input-append .add-on, .input-prepend .add-on {
   background-color: @grayDark;
+  text-shadow: none;
+  color: @white;
 }
 
 .alert {
@@ -699,7 +701,10 @@ a.bookmark-on:focus {
   padding: 4px 10px;
 }
 
-
 table.simple-pager-total-panel > tbody > tr >  td:last-of-type {
   padding-top:8px;
+}
+
+.btn .caret{
+  border-top: 4px solid @white;
 }


### PR DESCRIPTION
![image](https://f.cloud.github.com/assets/2565497/2325632/219db318-a3d8-11e3-97b4-00a9291790a7.png)
