### PR TITLE
fixed refresh rest datasource

### DIFF
--- a/opal-rest-client/src/main/java/org/obiba/opal/rest/client/magma/UriBuilder.java
+++ b/opal-rest-client/src/main/java/org/obiba/opal/rest/client/magma/UriBuilder.java
@@ -16,11 +16,11 @@ public class UriBuilder {
 
   private final Map<String, String> query = new LinkedHashMap<>();
 
-  UriBuilder(URI root) {
+  public UriBuilder(URI root) {
     this.root = root;
   }
 
-  UriBuilder(UriBuilder builder) {
+  public UriBuilder(UriBuilder builder) {
     root = builder.root;
     pathSegments.addAll(builder.pathSegments);
     query.putAll(builder.query);

--- a/opal-rest-client/src/test/java/org/obiba/opal/rest/client/RestDatasourceTest.java
+++ b/opal-rest-client/src/test/java/org/obiba/opal/rest/client/RestDatasourceTest.java
@@ -10,21 +10,43 @@
 package org.obiba.opal.rest.client;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Set;
 
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.obiba.magma.Datasource;
 import org.obiba.magma.MagmaEngine;
+import org.obiba.magma.ValueTable;
 import org.obiba.magma.ValueTableWriter;
 import org.obiba.magma.ValueTableWriter.ValueSetWriter;
 import org.obiba.magma.ValueTableWriter.VariableWriter;
 import org.obiba.magma.Variable;
 import org.obiba.magma.support.VariableEntityBean;
 import org.obiba.magma.type.BinaryType;
+import org.obiba.opal.rest.client.magma.OpalJavaClient;
 import org.obiba.opal.rest.client.magma.RestDatasource;
+import org.obiba.opal.rest.client.magma.UriBuilder;
+import org.obiba.opal.web.model.Magma;
+import org.obiba.opal.web.model.client.magma.TimestampsDto;
+
+import com.google.protobuf.Message;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  *
@@ -32,6 +54,9 @@ import org.obiba.opal.rest.client.magma.RestDatasource;
 public class RestDatasourceTest {
 
 //  private static final Logger log = LoggerFactory.getLogger(RestDatasourceTest.class);
+  OpalJavaClient mockOpalClient;
+  Magma.DatasourceDto datasourceDto;
+  Magma.TableDto tableDto;
 
   @BeforeClass
   public static void before() {
@@ -41,6 +66,29 @@ public class RestDatasourceTest {
   @AfterClass
   public static void after() {
     MagmaEngine.get().shutdown();
+  }
+
+  @Before
+  public void setup() throws URISyntaxException, IOException {
+    mockOpalClient = mock(OpalJavaClient.class);
+    datasourceDto = Magma.DatasourceDto.newBuilder()
+        .setName("test")
+        .setType("participant")
+        .addAllTable(Arrays.asList(new String[] {"tab1"}))
+        .setTimestamps(
+            Magma.TimestampsDto.newBuilder().setLastUpdate("2014-01-01T00:00:00Z").setCreated("2014-01-01T00:00:00Z").build())
+        .build();
+    tableDto = Magma.TableDto.newBuilder()
+        .setName("tab1")
+        .setEntityType("table")
+        .setDatasourceName("test")
+        .build();
+
+    when(mockOpalClient.newUri()).thenReturn(
+        new UriBuilder(new URI("https://localhost/")));
+
+    when(mockOpalClient.newUri(any(URI.class))).thenReturn(
+        new UriBuilder(new URI("https://localhost/")));
   }
 
   @Test
@@ -58,4 +106,53 @@ public class RestDatasourceTest {
     }
   }
 
+  @Test
+  public void testRefresh() throws URISyntaxException, IOException {
+    when(mockOpalClient
+        .getResource(any(Class.class), any(URI.class), any(Magma.DatasourceDto.Builder.class)))
+        .thenReturn(datasourceDto, tableDto);
+    Datasource ds = new RestDatasource("rest", mockOpalClient, "test");
+
+    Set<ValueTable> valueTables = ds.getValueTables();
+
+    assertEquals(1, valueTables.size());
+    verify(mockOpalClient, times(2)).getResource(any(Class.class), any(URI.class), any(Magma.DatasourceDto.Builder.class));
+  }
+
+  @Test
+  public void testRefreshNotNeeded() throws URISyntaxException, IOException {
+    when(mockOpalClient
+        .getResource(any(Class.class), any(URI.class), any(Magma.DatasourceDto.Builder.class)))
+        .thenReturn(datasourceDto, tableDto, datasourceDto);
+    Datasource ds = new RestDatasource("rest", mockOpalClient, "test");
+    ds.getValueTables(); //populate cached tables
+
+    Set<ValueTable> valueTables2 = ds.getValueTables();
+
+    assertEquals(1, valueTables2.size());
+    verify(mockOpalClient, times(3)).getResource(any(Class.class), any(URI.class), any(Magma.DatasourceDto.Builder.class));
+  }
+
+  @Test
+  public void testRefreshRemoveTable() throws URISyntaxException, IOException {
+    Magma.DatasourceDto datasourceDtoEmpty = Magma.DatasourceDto.newBuilder()
+        .setName("test")
+        .setType("participant")
+        .addAllTable(Arrays.asList(new String[] { }))
+        .setTimestamps(
+            Magma.TimestampsDto.newBuilder().setLastUpdate("2014-01-01T00:00:01Z").setCreated("2014-01-01T00:00:00Z")
+                .build())
+        .build();
+
+    when(mockOpalClient
+        .getResource(any(Class.class), any(URI.class), any(Magma.DatasourceDto.Builder.class)))
+        .thenReturn(datasourceDto, tableDto, datasourceDtoEmpty);
+    Datasource ds = new RestDatasource("rest", mockOpalClient, "test");
+    ds.getValueTables(); //populate cached tables
+
+    Set<ValueTable> valueTables2 = ds.getValueTables();
+
+    assertEquals(0, valueTables2.size());
+    verify(mockOpalClient, times(3)).getResource(any(Class.class), any(URI.class), any(Magma.DatasourceDto.Builder.class));
+  }
 }


### PR DESCRIPTION
fixed refresh rest datasource:
- used cached timestamps to perform refresh
- override getTimestamps to be consistent with remote datasource implementation
