### PR TITLE
Run Opal on IDE

### DIFF
--- a/opal-server/pom.xml
+++ b/opal-server/pom.xml
@@ -409,6 +409,31 @@
       </build>
 
     </profile>
+      <profile>
+          <id>deploy-dev</id>
+          <build>
+              <plugins>
+                  <plugin>
+                      <artifactId>maven-antrun-plugin</artifactId>
+                      <executions>
+                          <execution>
+                              <id>opal-dev</id>
+                              <phase>test</phase>
+                              <goals>
+                                  <goal>run</goal>
+                              </goals>
+                              <configuration>
+                                  <tasks>
+                                      <ant antfile="src/main/ant/opal-dev.xml" target="deploy"/>
+                                  </tasks>
+                              </configuration>
+                          </execution>
+                      </executions>
+                  </plugin>
+              </plugins>
+          </build>
+      </profile>
+
   </profiles>
 
 </project>

--- a/opal-server/src/main/ant/opal-dev.xml
+++ b/opal-server/src/main/ant/opal-dev.xml
@@ -1,0 +1,31 @@
+<project name="opal-dev" default="deploy" basedir="../../../">
+
+    <property name="target" location="${user.home}/.opal"/>
+
+    <xmlproperty file="../pom.xml" keeproot="false" prefix="pom"/>
+
+    <property name="opal.version" value="${pom.version}" />
+    <property name="opal.home" location="${target}/var/lib/opal"/>
+    <property name="opal.conf" location="${opal.home}/conf"/>
+    <property name="opal.dist" location="${target}/usr/share/opal"/>
+    <property name="opal.webapp" location="${opal.dist}/webapp"/>
+    <property name="opal.war" location="../opal-gwt-client/target/opal-gwt-client-${opal.version}.war"/>
+
+    <property name="build" location="build"/>
+    <property name="dist"  location="dist"/>
+
+    <target name="init">
+        <mkdir dir="${target}"/>
+        <mkdir dir="${opal.home}"/>
+        <mkdir dir="${opal.conf}"/>
+    </target>
+
+    <target name="deploy" depends="init">
+        <copy todir="${opal.conf}">
+            <fileset dir="src/main/conf"/>
+        </copy>
+        <unwar src="${opal.war}" dest="${opal.webapp}"  />
+
+    </target>
+
+</project>

--- a/opal-server/src/main/java/org/obiba/opal/server/OpalServer.java
+++ b/opal-server/src/main/java/org/obiba/opal/server/OpalServer.java
@@ -38,7 +38,7 @@ public class OpalServer {
   /**
    * Bridge/route all java.util.logging log records to the SLF4J API.
    */
-  private void configureSLF4JBridgeHandler() {
+  public static void configureSLF4JBridgeHandler() {
     //  remove existing handlers attached to java.util.logging root logger
     SLF4JBridgeHandler.removeHandlersForRootLogger();
 
@@ -46,7 +46,7 @@ public class OpalServer {
     SLF4JBridgeHandler.install();
   }
 
-  private void setProperties() {
+  public static void setProperties() {
     // Disable EHCache and Quartz usage tracker
     // http://martijndashorst.com/blog/2011/02/21/ehcache-and-quartz-phone-home-during-startup
     System.setProperty("net.sf.ehcache.skipUpdateCheck", "true");

--- a/opal-server/src/test/java/org/obiba/opal/server/DevOpalServer.java
+++ b/opal-server/src/test/java/org/obiba/opal/server/DevOpalServer.java
@@ -20,9 +20,12 @@ public class DevOpalServer extends OpalJettyServer {
         OpalServer.setProperties();
         OpalServer.configureSLF4JBridgeHandler();
 
-        //making sure we are not log spammed...
-        Logger logger = (Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-        logger.setLevel(Level.INFO);
+        //If using slf4j SimpleLogger, use this to change the log level (or set a property externally):
+        //System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "info"); // or "debug", "trace", etc.
+
+        //Previous versions used a different logging binding that could be configured like this:
+        //Logger logger = (Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+        //logger.setLevel(Level.INFO);
 
         new UpgradeCommand().execute(); //this is required to initialize some configuration (mandatory later on)
 
@@ -38,11 +41,8 @@ public class DevOpalServer extends OpalJettyServer {
         Properties props = new Properties();
 
         File sourcePropsFile = new File("src/main/deb/debian/opal.default");
-        InputStream in = new FileInputStream(sourcePropsFile);
-        try {
+        try (InputStream in = new FileInputStream(sourcePropsFile)) {
             props.load(in);
-        } finally {
-            in.close();
         }
 
         String userHome = System.getProperty("user.home");

--- a/opal-server/src/test/java/org/obiba/opal/server/DevOpalServer.java
+++ b/opal-server/src/test/java/org/obiba/opal/server/DevOpalServer.java
@@ -1,0 +1,56 @@
+package org.obiba.opal.server;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import org.obiba.opal.server.httpd.OpalJettyServer;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.util.Properties;
+
+//VM args for the launcher: -Xms1G -Xmx2G -XX:MaxPermSize=256M -XX:+UseG1GC
+public class DevOpalServer extends OpalJettyServer {
+
+    private static final String[] PROPS = { "OPAL_HOME", "OPAL_DIST", "OPAL_LOG" };
+    private static DevOpalServer INSTANCE;
+
+    public static void main(String[] args) throws Exception {
+
+        setOpalSysProperties();
+        OpalServer.setProperties();
+        OpalServer.configureSLF4JBridgeHandler();
+
+        //making sure we are not log spammed...
+        Logger logger = (Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+        logger.setLevel(Level.INFO);
+
+        new UpgradeCommand().execute(); //this is required to initialize some configuration (mandatory later on)
+
+        INSTANCE = new DevOpalServer();
+        INSTANCE.start();
+    }
+
+    /**
+     * Sets all opal folder system properties relative to ~/.opal instead of /
+     * @throws IOException
+     */
+    private static void setOpalSysProperties() throws IOException {
+        Properties props = new Properties();
+
+        File sourcePropsFile = new File("src/main/deb/debian/opal.default");
+        InputStream in = new FileInputStream(sourcePropsFile);
+        try {
+            props.load(in);
+        } finally {
+            in.close();
+        }
+
+        String userHome = System.getProperty("user.home");
+        String opalBase = userHome + "/.opal";
+
+        for (String prop: PROPS) {
+            System.setProperty(prop, opalBase + props.getProperty(prop)); //'relocate' all folders to  ~/.opal
+        }
+    }
+
+}

--- a/opal-server/src/test/java/org/obiba/opal/server/DevOpalServer.java
+++ b/opal-server/src/test/java/org/obiba/opal/server/DevOpalServer.java
@@ -1,11 +1,11 @@
 package org.obiba.opal.server;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
 import org.obiba.opal.server.httpd.OpalJettyServer;
-import org.slf4j.LoggerFactory;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Properties;
 
 //VM args for the launcher: -Xms1G -Xmx2G -XX:MaxPermSize=256M -XX:+UseG1GC
@@ -19,13 +19,6 @@ public class DevOpalServer extends OpalJettyServer {
         setOpalSysProperties();
         OpalServer.setProperties();
         OpalServer.configureSLF4JBridgeHandler();
-
-        //If using slf4j SimpleLogger, use this to change the log level (or set a property externally):
-        //System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "info"); // or "debug", "trace", etc.
-
-        //Previous versions used a different logging binding that could be configured like this:
-        //Logger logger = (Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-        //logger.setLevel(Level.INFO);
 
         new UpgradeCommand().execute(); //this is required to initialize some configuration (mandatory later on)
 


### PR DESCRIPTION
Provides a way to run Opal inside IDE.
The Opal process:
-is launched from the IDE (using a normal java application launch)
-uses the project classpath (including the declared maven dependencies)
-uses the foilder ~/.opal as the mountpoint for the relevant Opal folders usually present in / (/var/lib/opal and /usr/share/opal/webapp)

This helps in development speed, and everything but the webapp/GWT client files can picked from the IDE without the need of redeployment after compilation.

For synchronizing the webapp files or copying any missing configuration files, an ant build is provided, and can be run with either with
  mvn test -P deploy-dev
OR
  ant -f src/main/ant/opal-dev.xml

The opal-config.properties and shiro.ini files that configure the dev Opal are picked from the relocated folder ~/.opal/var/lib/opal/conf

In terms of code, this adds a class 
  org.obiba.opal.server.DevOpalServer extends OpalJettyServer

For this to be possible, we had to:
-make minor changes in OpalServer.java (make certain methods public and static)
-fix UpgradeCommand.java so it uses System.getProperty(...) instead of System.getenv().get(...)

The changes in UpgradeCommand.java were required so we pick OPAL_HOME and OPAL_DIST from java properties not system properties.
UpgradeCommand was reading system properties, unlike the other Opal classes (reading java properties).
This way we can set or modify programatically those variables, which is required to relocate folders to ~/.opal
