### PR TITLE
Adding flag to strictly forbid new variable creation on import

### DIFF
--- a/opal-core-api/src/main/java/org/obiba/opal/core/service/DataImportService.java
+++ b/opal-core-api/src/main/java/org/obiba/opal/core/service/DataImportService.java
@@ -34,6 +34,7 @@ public interface DataImportService {
    * @param destinationDatasourceName name of the destination datasource
    * @param allowIdentifierGeneration unknown participant will be created at importation time
    * @param ignoreUnknownIdentifier
+   * @param allowVariableCreation non-existing variables in the destination will be created
    * @param progressListener
    * @throws NoSuchIdentifiersMappingException
    * @throws NonExistentVariableEntitiesException if unitName is null and the source entities do not exist as public
@@ -42,7 +43,8 @@ public interface DataImportService {
    * @throws InterruptedException if the current thread was interrupted
    */
   void importData(String sourceDatasourceName, String destinationDatasourceName, boolean allowIdentifierGeneration,
-      boolean ignoreUnknownIdentifier, @Nullable DatasourceCopierProgressListener progressListener)
+      boolean allowVariableCreation, boolean ignoreUnknownIdentifier,
+      @Nullable DatasourceCopierProgressListener progressListener)
       throws NoSuchIdentifiersMappingException, NoSuchDatasourceException, NoSuchValueTableException,
       NonExistentVariableEntitiesException, IOException, InterruptedException;
 
@@ -52,6 +54,7 @@ public interface DataImportService {
    * @param sourceTableNames
    * @param destinationDatasourceName
    * @param allowIdentifierGeneration
+   * @param allowVariableCreation
    * @param ignoreUnknownIdentifier
    * @param progressListener
    * @throws NoSuchIdentifiersMappingException
@@ -60,7 +63,8 @@ public interface DataImportService {
    * @throws InterruptedException
    */
   void importData(List<String> sourceTableNames, String destinationDatasourceName, boolean allowIdentifierGeneration,
-      boolean ignoreUnknownIdentifier, @Nullable DatasourceCopierProgressListener progressListener)
+      boolean allowVariableCreation, boolean ignoreUnknownIdentifier,
+      @Nullable DatasourceCopierProgressListener progressListener)
       throws NoSuchIdentifiersMappingException, NoSuchDatasourceException, NoSuchValueTableException,
       NonExistentVariableEntitiesException, IOException, InterruptedException;
 
@@ -70,11 +74,12 @@ public interface DataImportService {
    * @param sourceValueTables
    * @param destinationDatasourceName
    * @param allowIdentifierGeneration
+   * @param allowVariableCreation
    * @param ignoreUnknownIdentifier
    * @param progressListener
    */
   void importData(Set<ValueTable> sourceValueTables, String destinationDatasourceName,
-      boolean allowIdentifierGeneration, boolean ignoreUnknownIdentifier,
+      boolean allowIdentifierGeneration, boolean allowVariableCreation, boolean ignoreUnknownIdentifier,
       @Nullable DatasourceCopierProgressListener progressListener)
       throws NoSuchIdentifiersMappingException, NonExistentVariableEntitiesException, IOException, InterruptedException;
 

--- a/opal-core-ws/src/main/java/org/obiba/opal/web/magma/TableResource.java
+++ b/opal-core-ws/src/main/java/org/obiba/opal/web/magma/TableResource.java
@@ -81,6 +81,8 @@ public interface TableResource {
    * @param unitName optional functional unit name
    * @param generateIds ignored if unit name is not specified, otherwise operation will fail if no entity can be found
    * in the given unit and creating a new entity is not allowed
+   * @param createVariables if true (default), unknown variables will be generated. Otherwise an error occurs if not
+   *                        all variables exist already.
    * @return
    * @throws IOException
    * @throws InterruptedException
@@ -90,6 +92,7 @@ public interface TableResource {
   Response updateValueSet(Magma.ValueSetsDto valueSetsDto, //
       @QueryParam("unit") String unitName, //
       @QueryParam("generateIds") @DefaultValue("false") boolean generateIds, //
+      @QueryParam("createVariables") @DefaultValue("true") boolean createVariables, //
       @QueryParam("ignoreUnknownIds") @DefaultValue("false") boolean ignoreUnknownIds)
       throws IOException, InterruptedException;
 

--- a/opal-core-ws/src/main/java/org/obiba/opal/web/magma/TableResourceImpl.java
+++ b/opal-core-ws/src/main/java/org/obiba/opal/web/magma/TableResourceImpl.java
@@ -152,7 +152,7 @@ public class TableResourceImpl extends AbstractValueTableResource implements Tab
 
   @Override
   public Response updateValueSet(ValueSetsDto valueSetsDto, String unitName, boolean generateIds,
-      boolean ignoreUnknownIds) throws IOException, InterruptedException {
+      boolean createVariables, boolean ignoreUnknownIds) throws IOException, InterruptedException {
     ValueTable vt = getValueTable();
     try {
       if(dataImportService == null) {
@@ -162,7 +162,8 @@ public class TableResourceImpl extends AbstractValueTableResource implements Tab
         // static writers will add entities and variables while writing values
         writeValueSets(ds.createWriter(vt.getName(), valueSetsDto.getEntityType()), valueSetsDto);
         dataImportService
-            .importData(ds.getValueTables(), vt.getDatasource().getName(), generateIds, ignoreUnknownIds, null);
+            .importData(ds.getValueTables(), vt.getDatasource().getName(), generateIds,
+                           createVariables, ignoreUnknownIds, null);
       }
     } catch(NoSuchIdentifiersMappingException ex) {
       return Response.status(BAD_REQUEST)

--- a/opal-core/src/main/java/org/obiba/opal/core/service/CopyValueTablesLockingAction.java
+++ b/opal-core/src/main/java/org/obiba/opal/core/service/CopyValueTablesLockingAction.java
@@ -49,6 +49,8 @@ class CopyValueTablesLockingAction extends LockingActionTemplate {
 
   private final boolean allowIdentifierGeneration;
 
+  private final boolean allowVariableCreation;
+
   private final boolean ignoreUnknownIdentifier;
 
   private final IdentifiersTableService identifiersTableService;
@@ -62,7 +64,8 @@ class CopyValueTablesLockingAction extends LockingActionTemplate {
   @SuppressWarnings("PMD.ExcessiveParameterList")
   CopyValueTablesLockingAction(IdentifiersTableService identifiersTableService, IdentifierService identifierService,
       TransactionTemplate txTemplate, Set<ValueTable> sourceTables, Datasource destination,
-      boolean allowIdentifierGeneration, boolean ignoreUnknownIdentifier, DatasourceCopierProgressListener progressListener) {
+      boolean allowIdentifierGeneration, boolean allowVariableCreation, boolean ignoreUnknownIdentifier,
+      DatasourceCopierProgressListener progressListener) {
     this.identifiersTableService = identifiersTableService;
     this.identifierService = identifierService;
     this.txTemplate = txTemplate;
@@ -74,6 +77,7 @@ class CopyValueTablesLockingAction extends LockingActionTemplate {
     });
     this.destination = destination;
     this.allowIdentifierGeneration = allowIdentifierGeneration;
+    this.allowVariableCreation = allowVariableCreation;
     this.ignoreUnknownIdentifier = ignoreUnknownIdentifier;
     this.progressListener = progressListener;
   }

--- a/opal-core/src/main/java/org/obiba/opal/core/service/CopyValueTablesLockingAction.java
+++ b/opal-core/src/main/java/org/obiba/opal/core/service/CopyValueTablesLockingAction.java
@@ -136,7 +136,7 @@ class CopyValueTablesLockingAction extends LockingActionTemplate {
             }));
             throw new IllegalArgumentException(
                 String.format("Variables do not exist in %s and creating new variables is disabled: %s",
-                                 vars, destinationTable.getTableReference()));
+                                 destinationTable.getTableReference(), vars));
           }
         }
       }

--- a/opal-python-client/src/main/python/opal/import_csv.py
+++ b/opal-python-client/src/main/python/opal/import_csv.py
@@ -32,7 +32,9 @@ def do_command(args):
         client = opal.core.OpalClient.build(opal.core.OpalClient.LoginInfo.parse(args))
         importer = opal.io.OpalImporter.build(client=client, destination=args.destination, tables=args.tables,
                                               incremental=args.incremental, limit=args.limit,identifiers=args.identifiers,
-                                              policy=args.policy, verbose=args.verbose)
+                                              policy=args.policy, verbose=args.verbose,
+                                              create_variables=args.create_variables)
+
         # print result
         extension_factory = OpalExtensionFactory(characterSet=args.characterSet, separator=args.separator,
                                                  quote=args.quote,

--- a/opal-python-client/src/main/python/opal/io.py
+++ b/opal-python-client/src/main/python/opal/io.py
@@ -18,6 +18,11 @@ def add_import_arguments(parser):
     parser.add_argument('--identifiers', '-id', required=False, help='Name of the ID mapping')
     parser.add_argument('--policy', '-po', required=False, help='ID mapping policy: required (each identifiers must be mapped prior importation, default), ignore (ignore unknown identifiers), generate (generate a system identifier for each unknown identifier)')
     parser.add_argument('--json', '-j', action='store_true', help='Pretty JSON formatting of the response')
+    parser.add_argument('--create-variables', '-cv', action='store_true',
+                        help='Create variables that do not yet exist in the destination (default)')
+    parser.add_argument('--no-create-variables', '-ncv', action='store_false', dest='create_variables',
+                        help='Do not create variables that do not exist in the destination.')
+    parser.set_defaults(create_variables=True)
 
 class OpalImporter:
     """
@@ -29,7 +34,8 @@ class OpalImporter:
             raise Exception("ExtensionFactoryInterface.add() method must be implemented by a concrete class.")
 
     @classmethod
-    def build(cls, client, destination, tables=None, incremental=None, limit=None, identifiers=None, policy=None, verbose=None):
+    def build(cls, client, destination, tables=None, incremental=None, limit=None, identifiers=None, policy=None, verbose=None,
+              create_variables=None):
         setattr(cls, 'client', client)
         setattr(cls, 'destination', destination)
         setattr(cls, 'tables', tables)
@@ -38,6 +44,7 @@ class OpalImporter:
         setattr(cls, 'identifiers', identifiers)
         setattr(cls, 'policy', policy)
         setattr(cls, 'verbose', verbose)
+        setattr(cls, 'createVariables', create_variables)
         return cls()
 
     def submit(self, extension_factory):
@@ -56,6 +63,7 @@ class OpalImporter:
         # import options
         options = opal.protobuf.Commands_pb2.ImportCommandOptionsDto()
         options.destination = self.destination
+        options.createVariables = self.createVariables
         # tables must be the ones of the transient
         tables2import = transient.table
         if self.tables:

--- a/opal-shell/src/main/java/org/obiba/opal/shell/commands/ImportCommand.java
+++ b/opal-shell/src/main/java/org/obiba/opal/shell/commands/ImportCommand.java
@@ -126,8 +126,8 @@ public class ImportCommand extends AbstractOpalRuntimeDependentCommand<ImportCom
     int errorCode = CRITICAL_ERROR;
     getShell().printf("  Importing datasource %s in %s...\n", options.getSource(), options.getDestination());
     try {
-      dataImportService.importData(options.getSource(), options.getDestination(), options.isForce(), options.isIgnore(),
-          new ImportProgressListener());
+      dataImportService.importData(options.getSource(), options.getDestination(), options.isForce(),
+          options.isCreateVariables(), options.isIgnore(), new ImportProgressListener());
       if(file != null) archive(file);
       errorCode = SUCCESS;
     } catch(NoSuchDatasourceException ex) {
@@ -152,8 +152,8 @@ public class ImportCommand extends AbstractOpalRuntimeDependentCommand<ImportCom
     int errorCode = CRITICAL_ERROR;
     getShell().printf("  Importing tables [%s] in %s ...\n", getTableNames(), options.getDestination());
     try {
-      dataImportService.importData(options.getTables(), options.getDestination(), options.isForce(), options.isIgnore(),
-          new ImportProgressListener());
+      dataImportService.importData(options.getTables(), options.getDestination(), options.isForce(), options.isCreateVariables(),
+          options.isIgnore(), new ImportProgressListener());
       if(file != null) archive(file);
       errorCode = SUCCESS;
     } catch(NoSuchDatasourceException | NoSuchValueTableException ex) {

--- a/opal-shell/src/main/java/org/obiba/opal/shell/commands/options/ImportCommandOptions.java
+++ b/opal-shell/src/main/java/org/obiba/opal/shell/commands/options/ImportCommandOptions.java
@@ -67,4 +67,7 @@ public interface ImportCommandOptions extends HelpOption {
   @Option(shortName = "c",
       description = "Use incremental import.")
   boolean isIncremental();
+
+  @Option(description = "Create new variables in the destination table if they do not yet exist.")
+  boolean isCreateVariables();
 }

--- a/opal-shell/src/main/java/org/obiba/opal/shell/web/ImportCommandOptionsDtoImpl.java
+++ b/opal-shell/src/main/java/org/obiba/opal/shell/web/ImportCommandOptionsDtoImpl.java
@@ -112,4 +112,9 @@ public class ImportCommandOptionsDtoImpl implements ImportCommandOptions {
   public boolean isIncremental() {
     return dto.getIncremental();
   }
+
+  @Override
+  public boolean isCreateVariables() {
+    return dto.getCreateVariables();
+  }
 }

--- a/opal-web-model/src/main/protobuf/Commands.proto
+++ b/opal-web-model/src/main/protobuf/Commands.proto
@@ -48,6 +48,7 @@ message ImportCommandOptionsDto {
   repeated string tables = 7;
   optional bool incremental = 9 [default = false];
   optional Identifiers.IdentifiersMappingConfigDto idConfig = 10;
+  optional bool createVariables = 11 [default = true];
 }
 
 message CopyCommandOptionsDto {


### PR DESCRIPTION
This was requested by our customer so importing data would not create any new variables.

Add ImportCommandOptionsDto.createVariables and python command line support
The python client includes options for setting create-variables. Default to true for backward compatibility
