### PR TITLE
bugfix Values tab, visible variables glitch

### DIFF
--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/presenter/ValuesTablePresenter.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/presenter/ValuesTablePresenter.java
@@ -259,8 +259,8 @@ public class ValuesTablePresenter extends PresenterWidget<ValuesTablePresenter.D
               // Do not show "SearchQueryIsInvalid" errors: the query might be invalid because it is being typed in
               if(errorDto != null && !"SearchQueryIsInvalid".equals(errorDto.getStatus())) {
                 fireEvent(NotificationEvent.newBuilder().error(TranslationsUtils
-                    .replaceArguments(translations.userMessageMap().get(errorDto.getStatus()),
-                        errorDto.getArgumentsArray())).build());
+                        .replaceArguments(translations.userMessageMap().get(errorDto.getStatus()),
+                                errorDto.getArgumentsArray())).build());
               }
             }
           }, Response.SC_BAD_REQUEST)//
@@ -391,6 +391,8 @@ public class ValuesTablePresenter extends PresenterWidget<ValuesTablePresenter.D
         script.append("/)");
         currentVariablesFilterSelect = script.toString();
         link.append(currentVariablesFilterSelect);
+      } else {
+        currentVariablesFilterSelect = ""; //we need to clear currentVariablesFilterSelect, as it will be used later on
       }
       doRequest(offset, link.toString());
     }

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/ui/celltable/ValueRenderer.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/ui/celltable/ValueRenderer.java
@@ -81,6 +81,9 @@ public enum ValueRenderer {
   }
 
   protected String getValue(ValueSetsDto.ValueDto value) {
+    if (value == null) {
+      return ""; //avoid a javascript 'NullPointerException' when there is no value
+    }
     return transform(value.getValue());
   }
 


### PR DESCRIPTION
In Opal GWT, table values tab, when we define 'number of visible variables' bigger than 5 (15 lets say), the table will have drawing errors and be incomplete not displaying the rightmost variable values.
This is happening for 2 reasons: 
* currentVariablesFilterSelect was not being properly updated in ValuesTablePresenter.DataFetcherImpl. request
* ValueRenderer.getValue was not 'NullPointerException' safe

This solves that problem