### PR TITLE
GWT client now tracks the session timeout

### DIFF
--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/presenter/ApplicationPresenter.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/presenter/ApplicationPresenter.java
@@ -9,6 +9,21 @@
  ******************************************************************************/
 package org.obiba.opal.web.gwt.app.client.presenter;
 
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.event.shared.GwtEvent;
+import com.google.gwt.http.client.Request;
+import com.google.gwt.http.client.Response;
+import com.google.inject.Inject;
+import com.google.web.bindery.event.shared.EventBus;
+import com.gwtplatform.mvp.client.HasUiHandlers;
+import com.gwtplatform.mvp.client.Presenter;
+import com.gwtplatform.mvp.client.View;
+import com.gwtplatform.mvp.client.annotations.ContentSlot;
+import com.gwtplatform.mvp.client.annotations.ProxyStandard;
+import com.gwtplatform.mvp.client.proxy.PlaceManager;
+import com.gwtplatform.mvp.client.proxy.RevealContentHandler;
+import com.gwtplatform.mvp.client.proxy.RevealRootContentEvent;
+import com.gwtplatform.mvp.shared.proxy.PlaceRequest;
 import org.obiba.opal.web.gwt.app.client.administration.configuration.event.GeneralConfigSavedEvent;
 import org.obiba.opal.web.gwt.app.client.administration.presenter.RequestAdministrationPermissionEvent;
 import org.obiba.opal.web.gwt.app.client.event.ModalClosedEvent;
@@ -39,26 +54,11 @@ import org.obiba.opal.web.gwt.rest.client.ResourceRequestBuilderFactory;
 import org.obiba.opal.web.gwt.rest.client.ResponseCodeCallback;
 import org.obiba.opal.web.gwt.rest.client.UriBuilder;
 import org.obiba.opal.web.gwt.rest.client.UriBuilders;
+import org.obiba.opal.web.gwt.rest.client.UserSessionTracker;
 import org.obiba.opal.web.gwt.rest.client.authorization.HasAuthorization;
 import org.obiba.opal.web.gwt.rest.client.event.UnhandledResponseEvent;
 import org.obiba.opal.web.model.client.opal.FileDto;
 import org.obiba.opal.web.model.client.search.QueryResultDto;
-
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.event.shared.GwtEvent;
-import com.google.gwt.http.client.Request;
-import com.google.gwt.http.client.Response;
-import com.google.inject.Inject;
-import com.google.web.bindery.event.shared.EventBus;
-import com.gwtplatform.mvp.client.HasUiHandlers;
-import com.gwtplatform.mvp.client.Presenter;
-import com.gwtplatform.mvp.client.View;
-import com.gwtplatform.mvp.client.annotations.ContentSlot;
-import com.gwtplatform.mvp.client.annotations.ProxyStandard;
-import com.gwtplatform.mvp.client.proxy.PlaceManager;
-import com.gwtplatform.mvp.client.proxy.RevealContentHandler;
-import com.gwtplatform.mvp.client.proxy.RevealRootContentEvent;
-import com.gwtplatform.mvp.shared.proxy.PlaceRequest;
 
 /**
  *
@@ -120,38 +120,38 @@ public class ApplicationPresenter extends Presenter<ApplicationPresenter.Display
   @Override
   protected void onBind() {
     addRegisteredHandler(FileSelectionRequestEvent.getType(), new FileSelectionRequestEvent.Handler() {
-      @Override
-      public void onFileSelectionRequired(FileSelectionRequestEvent event) {
-        FileSelectorPresenter fsp = fileSelectorProvider.get();
-        fsp.handle(event);
-      }
+        @Override
+        public void onFileSelectionRequired(FileSelectionRequestEvent event) {
+            FileSelectorPresenter fsp = fileSelectorProvider.get();
+            fsp.handle(event);
+        }
     });
     addRegisteredHandler(GeoValueDisplayEvent.getType(), new GeoValueDisplayEvent.Handler() {
 
-      @Override
-      public void onGeoValueDisplay(GeoValueDisplayEvent event) {
-        ValueMapPopupPresenter vmp = valueMapPopupProvider.get();
-        vmp.handle(event);
-      }
+        @Override
+        public void onGeoValueDisplay(GeoValueDisplayEvent event) {
+            ValueMapPopupPresenter vmp = valueMapPopupProvider.get();
+            vmp.handle(event);
+        }
     });
     addRegisteredHandler(FileDownloadRequestEvent.getType(), new FileDownloadRequestEvent.FileDownloadRequestHandler() {
 
-      @Override
-      public void onFileDownloadRequest(FileDownloadRequestEvent event) {
-        getView().getDownloader().setUrl(urlBuilder.buildAbsoluteUrl(event.getUrl()));
-      }
+        @Override
+        public void onFileDownloadRequest(FileDownloadRequestEvent event) {
+            getView().getDownloader().setUrl(urlBuilder.buildAbsoluteUrl(event.getUrl()));
+        }
     });
     addRegisteredHandler(FilesDownloadRequestEvent.getType(),
-        new FilesDownloadRequestEvent.FilesDownloadRequestHandler() {
-          @Override
-          public void onFilesDownloadRequest(FilesDownloadRequestEvent event) {
-            UriBuilder uriBuilder = UriBuilder.create().fromPath(FileDtos.getLink(event.getParent()));
-            for(FileDto child : event.getChildren()) {
-              uriBuilder.query("file", child.getName());
-            }
-            getView().getDownloader().setUrl(urlBuilder.buildAbsoluteUrl(uriBuilder.build()));
-          }
-        });
+            new FilesDownloadRequestEvent.FilesDownloadRequestHandler() {
+                @Override
+                public void onFilesDownloadRequest(FilesDownloadRequestEvent event) {
+                    UriBuilder uriBuilder = UriBuilder.create().fromPath(FileDtos.getLink(event.getParent()));
+                    for (FileDto child : event.getChildren()) {
+                        uriBuilder.query("file", child.getName());
+                    }
+                    getView().getDownloader().setUrl(urlBuilder.buildAbsoluteUrl(uriBuilder.build()));
+                }
+            });
 
     // Update search box on event
     addRegisteredHandler(DatasourceSelectionChangeEvent.getType(),
@@ -207,6 +207,7 @@ public class ApplicationPresenter extends Presenter<ApplicationPresenter.Display
     refreshApplicationName();
 
     authorize();
+    UserSessionTracker.getInstance().configure();
   }
 
   private void refreshApplicationName() {

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/rest/client/DefaultResourceRequestBuilder.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/rest/client/DefaultResourceRequestBuilder.java
@@ -213,6 +213,7 @@ public class DefaultResourceRequestBuilder<T extends JavaScriptObject> implement
   @Override
   public Request send() {
     try {
+        UserSessionTracker.getInstance().sessionTouched();
       return build().send();
     } catch(RequestException e) {
       eventBus.fireEvent(new RequestErrorEvent.Builder().exception(e).build());

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/rest/client/UserSessionTracker.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/rest/client/UserSessionTracker.java
@@ -1,0 +1,83 @@
+package org.obiba.opal.web.gwt.rest.client;
+
+import com.google.gwt.http.client.Response;
+import com.google.gwt.user.client.Timer;
+import com.google.gwt.user.client.Window;
+import org.obiba.opal.web.model.client.opal.GeneralConf;
+
+/**
+ * Singleton that keeps track of Opal REST calls and session timeout.
+ * It uses a timer with a delay equal to the session timeout.
+ * Every time a REST call is made, the timer is reset.
+ * When timer reaches 0, browser location is set to login page.
+ */
+public class UserSessionTracker {
+
+    private static UserSessionTracker INSTANCE = new UserSessionTracker();
+
+    private Timer timeoutTimer = null;
+    private Long clientSessionTimeout;
+
+    public static final UserSessionTracker getInstance() {
+        return INSTANCE;
+    }
+
+    private UserSessionTracker() {
+
+    }
+
+    public void configure() {
+        if (timeoutTimer != null) {
+            resetTimer(true);
+        } else {
+            requestClientSessionTimeout();
+        }
+    }
+
+    private void resetTimer(boolean restart) {
+        if (timeoutTimer != null) {
+            timeoutTimer.cancel();
+            timeoutTimer = null;
+        }
+
+        if (clientSessionTimeout != null && restart) {
+            timeoutTimer = new Timer() {
+                @Override
+                public void run() {
+                    timedOut();
+                }
+            };
+            timeoutTimer.schedule(clientSessionTimeout.intValue());
+        }
+    }
+
+    private void timedOut() {
+        Window.Location.assign("/");
+    }
+
+    public void sessionTouched() {
+        resetTimer(true);
+    }
+
+    private void handleGeneralConf(GeneralConf conf) {
+        if (conf.hasClientSessionTimeout()) {
+            clientSessionTimeout = (long)conf.getClientSessionTimeout();
+        } else {
+            clientSessionTimeout = null;
+        }
+    }
+
+    private void requestClientSessionTimeout() {
+        ResourceRequestBuilderFactory.<GeneralConf>newBuilder()
+                .forResource(UriBuilders.SYSTEM_CONF_GENERAL.create().build())
+                .get()
+                .withCallback(new ResourceCallback<GeneralConf>() {
+                    @Override
+                    public void onResource(Response response, GeneralConf resource) {
+                        handleGeneralConf(resource);
+                    }
+                })
+                .send();
+    }
+
+}

--- a/opal-server/src/main/conf/opal-config.properties
+++ b/opal-server/src/main/conf/opal-config.properties
@@ -124,3 +124,8 @@
 # Crowd client config
 crowd.properties.path = file:${OPAL_HOME}/conf/crowd/crowd.properties
 crowd-ehcache.xml.path = file:${OPAL_HOME}/conf/crowd/crowd-ehcache.xml
+
+
+# Enables client-side session timeout handling.
+# When enabled, Opal will return session timeout information to clients, which can use it to manage timeout on their side.
+#org.obiba.opal.web.client.timeout.enabled=true

--- a/opal-web-model/src/main/protobuf/Opal.proto
+++ b/opal-web-model/src/main/protobuf/Opal.proto
@@ -303,6 +303,7 @@ message GeneralConf {
   repeated string languages = 2; // replaces the property org.obiba.opal.languages
   required string defaultCharSet = 3 [default = "ISO-8859-1"]; // replaces the property org.obiba.opal.charset.default
   optional string publicURL = 4;
+  optional int64 clientSessionTimeout = 5;
 }
 
 message AttributeConf {


### PR DESCRIPTION
Our customer requested Opal webapp to redirect to login page as soon as the session timeout is reached. This is meant to clear the screen and not leave any private information visible.
## Design:
- Added a globalSessionTimeout field to GeneralConf protobuf message
- If properly enabled, REST resource /system/conf/general will fill in the new field
- In GWT, UserSessionTracker.configure (called from ApplicationPresenter. onReveal) will read the new field, and if set create a Timer
- Every time a request is sent to Opal, the timeout is restarted (in DefaultResourceRequestBuilder.send)
- When the timer reaches 0, the app is sent to / (on the same domain)
- To configure this, opal-config.properties should have `org.obiba.opal.web.client.timeout.enabled=true`
