### PR TITLE
Improvement: Unrecognized/Unsupported browser now shows an alert with clear message

### DIFF
--- a/opal-gwt-client/src/main/resources/org/obiba/opal/web/gwt/app/public/undefined.cache.js
+++ b/opal-gwt-client/src/main/resources/org/obiba/opal/web/gwt/app/public/undefined.cache.js
@@ -1,0 +1,1 @@
+ui.onScriptDownloaded(alert('Please use one of these browsers:\n  -Chrome\n  -Firefox\n  -Internet Explorer 8, 9, 10 or 11\nIf your browser is in this list and you still see this warning, \nthen your browser was not properly recognized.\nIn that case, use one of the others.'));


### PR DESCRIPTION
Our customer requested a clear message in Opal webapp when they use a browser that is not supported. 
Moreover, one of the sites reported that IE 11 was not wortking. That happened because something on that configuration was preventing GWT from getting the user.agent, and so Opal didn't work in that site.

Anyway, in both cases the browser is not considered supported and gets this message, which was the customer intent