### PR TITLE
Removing support for IE8 on GWT permutations and warning dialog

### DIFF
--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/GwtApp.gwt.xml
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/GwtApp.gwt.xml
@@ -123,6 +123,8 @@
     </any>
   </replace-with>
 
+  <set-property name='user.agent' value='gecko1_8,safari,ie9,ie10'/>
+
   <!-- This will limit the compile to a single browser: -->
   <!-- Firefox 3.x -->
   <!--<set-property name='user.agent' value='gecko1_8'/>-->

--- a/opal-gwt-client/src/main/resources/org/obiba/opal/web/gwt/app/public/undefined.cache.js
+++ b/opal-gwt-client/src/main/resources/org/obiba/opal/web/gwt/app/public/undefined.cache.js
@@ -1,1 +1,1 @@
-ui.onScriptDownloaded(alert('Please use one of these browsers:\n  -Chrome\n  -Firefox\n  -Internet Explorer 8, 9, 10 or 11\nIf your browser is in this list and you still see this warning, \nthen your browser was not properly recognized.\nIn that case, use one of the others.'));
+ui.onScriptDownloaded(alert('Please use one of these browsers:\n  -Chrome\n  -Firefox\n  -Internet Explorer 9, 10 or 11\nIf your browser is in this list and you still see this warning, \nthen your browser was not properly recognized.\nIn that case, use one of the others.'));


### PR DESCRIPTION
Opal doesn't work with IE8 (some javascript error)
Given this and the age of this browser, we removed support for it.
Its no longer a permutation for GWT and was removed from the list of supported browsers in the alert.