### PR TITLE
OPAL-2786 - fixed install and remove scripts

### DIFF
--- a/opal-server/pom.xml
+++ b/opal-server/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <install.dir>/usr/share</install.dir>
-    <opal.dir>${install.dir}/opal-server</opal.dir>
+    <opal.dir>${install.dir}/opal-server-${project.version}</opal.dir>
     <package.name>opal-server-${project.version}</package.name>
     <dist.location>${basedir}/target/${package.name}-dist/${package.name}</dist.location>
   </properties>

--- a/opal-server/src/main/rpm/scripts/postinstall.sh
+++ b/opal-server/src/main/rpm/scripts/postinstall.sh
@@ -4,6 +4,8 @@
 
 set -e
 
+NAME=opal
+
 # summary of how this script can be called:
 #        * <postinst> `configure' <most-recently-configured-version>
 #        * <old-postinst> `abort-upgrade' <new version>
@@ -16,11 +18,10 @@ set -e
 # for details, see http://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
-NAME=opal
-
-[ -r /etc/default/$NAME ] && . /etc/default/$NAME
-
 installOrUpdate() {
+
+  [ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
   # Opal file structure on Debian
   # /etc/opal: configuration
   # /usr/share/opal: executable
@@ -28,7 +29,8 @@ installOrUpdate() {
   # /var/log: logs
 
   rm -f /usr/share/opal
-  ln -s /usr/share/opal-* /usr/share/opal
+  new_release="$(ls -t /usr/share/ |grep opal-server|head -1)"
+  ln -s /usr/share/${new_release} /usr/share/opal
 
   if [ ! -e /var/lib/opal/conf ] ; then
     ln -s /etc/opal /var/lib/opal/conf
@@ -36,7 +38,7 @@ installOrUpdate() {
 
   EXPORT_FILE=$OPAL_HOME/data/orientdb/opal-config.export
 
-  JAR_CMD="java -jar /usr/share/opal-*/tools/lib/opal-config-migrator-*-cli.jar"
+  JAR_CMD="java -jar /usr/share/opal/tools/lib/opal-config-migrator-*-cli.jar"
 
   [ -r $OPAL_HOME/data/orientdb/opal-config ] && $JAR_CMD --check $OPAL_HOME/data/orientdb/opal-config && \
       { $JAR_CMD $OPAL_HOME/data/orientdb/opal-config $EXPORT_FILE  && \

--- a/opal-server/src/main/rpm/scripts/postrm.sh
+++ b/opal-server/src/main/rpm/scripts/postrm.sh
@@ -17,11 +17,10 @@ set -e
 # for details, see http://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
-
 case "$1" in
 	0)
     userdel -f opal || true
-    rm -rf /var/lib/opal /var/log/opal /tmp/opal /etc/opal /usr/share/opal
+    rm -rf /run/opal /var/log/opal /tmp/opal
   ;;
 esac
 

--- a/opal-server/src/main/rpm/scripts/preinstall.sh
+++ b/opal-server/src/main/rpm/scripts/preinstall.sh
@@ -8,7 +8,19 @@ if [ $? != 0 ]; then
     useradd -r -g adm -d /var/lib/opal -s /sbin/nologin \
         -c "User for Opal" opal
 else
-    usermod -d /var/lib/opal opal
+
+  # stop the service if running
+  if service opal status > /dev/null; then
+    if which service >/dev/null 2>&1; then
+      service opal stop
+    elif which invoke-rc.d >/dev/null 2>&1; then
+      invoke-rc.d opal stop
+    else
+      /etc/init.d/opal stop
+    fi
+  fi
+
+  usermod -d /var/lib/opal opal
 fi
 
 exit 0

--- a/opal-server/src/main/rpm/scripts/prerm.sh
+++ b/opal-server/src/main/rpm/scripts/prerm.sh
@@ -28,10 +28,13 @@ stopOpalServer() {
   fi
 }
 
-migrationCheck() {
+backupOrientDb() {
+  # Read configuration variable file if it is present
+  [ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
   EXPORT_FILE=$OPAL_HOME/data/orientdb/opal-config.export
   echo "prerm migration check ..."
-  JAR_CMD="java -jar /usr/share/opal-*/tools/lib/opal-config-migrator-*-cli.jar"
+  JAR_CMD="java -jar /usr/share/opal/tools/lib/opal-config-migrator-*-cli.jar"
   $JAR_CMD --check $OPAL_HOME/data/orientdb/opal-config && \
   { $JAR_CMD $OPAL_HOME/data/orientdb/opal-config $EXPORT_FILE  && \
   echo "prerm legacy export completed ..." && \
@@ -43,7 +46,7 @@ if [ "$1" -eq 0 ] || [ "$1" -ge 2 ]; then
 
   if [ "$1" -ge 2 ]; then
     # upgrading
-    migrationCheck
+    backupOrientDb
   fi
 
   if [ "$1" -eq 0 ]; then


### PR DESCRIPTION
This patch requires that the old installed packages be removed as follows:

/etc/init.d/rserver stop
rpm -e rserver-admin-<version> --noscripts  # no data files will be removed