### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/opal-config-migrator/src/main/java/org/obiba/opal/tools/LegacyOrientDbExporter.java
+++ b/opal-config-migrator/src/main/java/org/obiba/opal/tools/LegacyOrientDbExporter.java
@@ -11,6 +11,9 @@ public class LegacyOrientDbExporter {
 
   private static final String PASSWORD = "admin";
 
+  private LegacyOrientDbExporter() {
+  }
+
   public static void main(String[] args) {
     boolean check = false;
 

--- a/opal-core/src/main/java/org/obiba/opal/core/tools/OrientDbUtil.java
+++ b/opal-core/src/main/java/org/obiba/opal/core/tools/OrientDbUtil.java
@@ -13,6 +13,9 @@ import com.google.common.base.Throwables;
 
 public class OrientDbUtil {
 
+  private OrientDbUtil() {
+  }
+
   public static void main(String[] args) {
     if(args.length != 2) {
       throw new IllegalArgumentException("invalid args");

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/support/PlaceRequestHelper.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/support/PlaceRequestHelper.java
@@ -8,6 +8,9 @@ import com.gwtplatform.mvp.shared.proxy.PlaceRequest;
 
 public class PlaceRequestHelper {
 
+  private PlaceRequestHelper() {
+  }
+
   public static PlaceRequest.Builder createRequestBuilder(PlaceRequest request) {
     PlaceRequest.Builder builder = createRequestBuilderWithNameToken(request);
 

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/support/ValueRenderingHelper.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/support/ValueRenderingHelper.java
@@ -18,6 +18,9 @@ public class ValueRenderingHelper {
 
   private static final long GB = MB * KB;
 
+  private ValueRenderingHelper() {
+  }
+
   public static String getSizeWithUnit(double size) {
     if(size < KB) {
       return (long) size + " B";


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.