### PR TITLE
 Primitives should not be boxed just for "String" conversion

### DIFF
--- a/opal-core/src/main/java/org/obiba/opal/core/service/QuartzTablesCreator.java
+++ b/opal-core/src/main/java/org/obiba/opal/core/service/QuartzTablesCreator.java
@@ -191,7 +191,7 @@ public class QuartzTablesCreator {
    * @param statements the list that will contain the individual statements
    */
   public static void splitSqlScript(String script, char delim, Collection<String> statements) {
-    splitSqlScript(script, "" + delim, DEFAULT_COMMENT_PREFIX, statements);
+    splitSqlScript(script, Character.toString(delim), DEFAULT_COMMENT_PREFIX, statements);
   }
 
   /**

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/administration/identifiers/presenter/IdentifiersTablePresenter.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/administration/identifiers/presenter/IdentifiersTablePresenter.java
@@ -101,8 +101,8 @@ public class IdentifiersTablePresenter extends PresenterWidget<IdentifiersTableP
 
   @Override
   public void onIdentifiersRequest(TableDto identifiersTable, String select, final int offset, int limit) {
-    String uri = UriBuilders.IDENTIFIERS_TABLE_VALUESETS.create().query("select", select).query("offset", "" + offset)
-        .query("limit", "" + limit).build(identifiersTable.getName());
+    String uri = UriBuilders.IDENTIFIERS_TABLE_VALUESETS.create().query("select", select).query("offset", Integer.toString(offset))
+        .query("limit", Integer.toString(limit)).build(identifiersTable.getName());
     ResourceRequestBuilderFactory.<ValueSetsDto>newBuilder() //
         .forResource(uri) //
         .withCallback(new ResourceCallback<ValueSetsDto>() {

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/administration/identifiers/view/GenerateIdentifiersModalView.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/administration/identifiers/view/GenerateIdentifiersModalView.java
@@ -130,7 +130,7 @@ public class GenerateIdentifiersModalView extends ModalPopupViewWithUiHandlers<G
 
   @Override
   public void setDefault(int sizeNb, String prefixStr) {
-    size.setValue(sizeNb + "");
+    size.setValue(Integer.toString(sizeNb));
     prefix.setText(prefixStr);
     sampleIdentifier.setText(generateSampleIdentifier());
   }

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/project/admin/ProjectAdministrationPresenter.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/project/admin/ProjectAdministrationPresenter.java
@@ -182,7 +182,7 @@ public class ProjectAdministrationPresenter extends PresenterWidget<ProjectAdmin
         }
       };
 
-      UriBuilder uri = UriBuilders.PROJECT.create().query("archive", archive + "");
+      UriBuilder uri = UriBuilders.PROJECT.create().query("archive", Boolean.toString(archive));
       ResourceRequestBuilderFactory.newBuilder() //
           .forResource(uri.build(projectDto.getName())) //
           .withCallback(callbackHandler, SC_OK, SC_FORBIDDEN, SC_INTERNAL_SERVER_ERROR, SC_NOT_FOUND) //

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/ui/DiffTable.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/ui/DiffTable.java
@@ -60,16 +60,16 @@ public class DiffTable extends DefaultFlexTable {
     Widget lineStartWidget;
 
     if(line.charAt(0) == '+') {
-      setWidget(row, 1, new Label(bLineNumber++ + ""));
+      setWidget(row, 1, new Label(Integer.toString(bLineNumber++)));
       lineStartWidget = new Label("+");
       style = "diff-add";
     } else if(line.charAt(0) == '-') {
-      setWidget(row, 0, new Label(aLineNumber++ + ""));
+      setWidget(row, 0, new Label(Integer.toString(aLineNumber++)));
       lineStartWidget = new Label("-");
       style = "diff-rm";
     } else {
-      setWidget(row, 0, new Label(aLineNumber++ + ""));
-      setWidget(row, 1, new Label(bLineNumber++ + ""));
+      setWidget(row, 0, new Label(Integer.toString(aLineNumber++)));
+      setWidget(row, 1, new Label(Integer.toString(bLineNumber++)));
       lineStartWidget = new HTMLPanel(new SafeHtmlBuilder().appendHtmlConstant("&nbsp;").toSafeHtml());
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2131 - “Primitives should not be boxed just for "String" conversion”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2131
Please let me know if you have any questions.
Ayman Abdelghany.