### PR TITLE
Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/administration/identifiers/presenter/ImportIdentifiersMappingModalPresenter.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/administration/identifiers/presenter/ImportIdentifiersMappingModalPresenter.java
@@ -143,7 +143,7 @@ public class ImportIdentifiersMappingModalPresenter
     String[] mappedIds = identifiers.split("\\n");
 
     // not empty and same length
-    StringBuffer str = new StringBuffer();
+    StringBuilder str = new StringBuilder();
     for(int i = 0; i < systemIds.length; i++) {
       String sId = systemIds[i].trim();
       String mId = mappedIds[i].trim();

--- a/opal-r/src/main/java/org/obiba/opal/r/MagmaAssignROperation.java
+++ b/opal-r/src/main/java/org/obiba/opal/r/MagmaAssignROperation.java
@@ -241,7 +241,7 @@ public class MagmaAssignROperation extends AbstractROperation {
 
     private void doAssignDataFrame(String... names) {
       // create the data.frame from the vectors
-      StringBuffer args = new StringBuffer();
+      StringBuilder args = new StringBuilder();
       for(String name : names) {
         if(args.length() > 0) args.append(", ");
         args.append("'").append(name).append("'=").append(getTmpVectorName(symbol, name));

--- a/opal-r/src/main/java/org/obiba/opal/r/StringAssignROperation.java
+++ b/opal-r/src/main/java/org/obiba/opal/r/StringAssignROperation.java
@@ -44,7 +44,7 @@ public class StringAssignROperation extends AbstractROperation {
 
   @Override
   public String toString() {
-    StringBuffer buffer = new StringBuffer();
+    StringBuilder buffer = new StringBuilder();
     for(Entry<String, List<String>> entry : symbols.entrySet()) {
       for(String content : entry.getValue()) {
         buffer.append(entry.getKey()).append(" <- ").append(content).append("\n");

--- a/opal-reporting/src/main/java/org/obiba/opal/reporting/service/r/RReportServiceImpl.java
+++ b/opal-reporting/src/main/java/org/obiba/opal/reporting/service/r/RReportServiceImpl.java
@@ -176,7 +176,7 @@ public class RReportServiceImpl implements ReportService {
    * @throws IOException
    */
   private void writeFileToR(OpalRSession rSession, File file) throws IOException {
-    StringBuffer script = new StringBuffer("writeLines(");
+    StringBuilder script = new StringBuilder("writeLines(");
     String content = readFileInString(file.getAbsolutePath());
     script.append("'").append(content.replace("\\", "\\\\").replace("'", "\\'").replace("\n", "\\n")).append("', '")
         .append(file.getName()).append("')");

--- a/opal-shell/src/main/java/org/obiba/opal/shell/commands/CopyCommand.java
+++ b/opal-shell/src/main/java/org/obiba/opal/shell/commands/CopyCommand.java
@@ -165,7 +165,7 @@ public class CopyCommand extends AbstractOpalRuntimeDependentCommand<CopyCommand
   }
 
   public String toString() {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
 
     sb.append("copy");
 
@@ -413,7 +413,7 @@ public class CopyCommand extends AbstractOpalRuntimeDependentCommand<CopyCommand
     return outputFile;
   }
 
-  private void appendOption(StringBuffer sb, String option, boolean optionSpecified, String value) {
+  private void appendOption(StringBuilder sb, String option, boolean optionSpecified, String value) {
     if(optionSpecified) {
       sb.append(" --");
       sb.append(option);
@@ -422,14 +422,14 @@ public class CopyCommand extends AbstractOpalRuntimeDependentCommand<CopyCommand
     }
   }
 
-  private void appendFlag(StringBuffer sb, String flag, boolean value) {
+  private void appendFlag(StringBuilder sb, String flag, boolean value) {
     if(value) {
       sb.append(" --");
       sb.append(flag);
     }
   }
 
-  private void appendUnparsedList(StringBuffer sb, Iterable<String> unparsedList) {
+  private void appendUnparsedList(StringBuilder sb, Iterable<String> unparsedList) {
     for(String unparsed : unparsedList) {
       sb.append(' ');
       sb.append(unparsed);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149
Please let me know if you have any questions.
Ayman Abdelghany.