### PR TITLE
rename admin role to opal-administrator

### DIFF
--- a/opal-server/src/main/conf/shiro.ini
+++ b/opal-server/src/main/conf/shiro.ini
@@ -22,7 +22,7 @@
 #
 # Format is:
 # username=password[,role]*
-administrator = $shiro1$SHA-256$500000$dxucP0IgyO99rdL0Ltj1Qg==$qssS60kTC7TqE61/JFrX/OEk0jsZbYXjiGhR7/t+XNY=,admin
+administrator = $shiro1$SHA-256$500000$dxucP0IgyO99rdL0Ltj1Qg==$qssS60kTC7TqE61/JFrX/OEk0jsZbYXjiGhR7/t+XNY=,opal-administrator
 
 
 [roles]
@@ -30,4 +30,4 @@ administrator = $shiro1$SHA-256$500000$dxucP0IgyO99rdL0Ltj1Qg==$qssS60kTC7TqE61/
 # when you only need a small number of statically-defined roles.
 # Format is:
 # role=permission[,permission]*
-admin = *
+opal-administrator = *


### PR DESCRIPTION
to be consistent with mica2 (where the admin group is called `mica-administrator`) and to be out-of-the-box compatible with agate (where the opal admin role is defined as `opal-administrator`)