### PR TITLE
OPAL-2875 Commands for import/export of VCF files added

### DIFF
--- a/opal-core-ws/src/main/java/org/obiba/opal/web/vcf/VCFStoreResource.java
+++ b/opal-core-ws/src/main/java/org/obiba/opal/web/vcf/VCFStoreResource.java
@@ -49,19 +49,6 @@ public interface VCFStoreResource {
   List<Plugins.VCFSummaryDto> getVCFList();
 
   /**
-   * Add a VCF file at the specified location in Opal file system. If name is not provided, the base name of the file
-   * will be used.
-   *
-   * @param uriInfo
-   * @param vcfPath
-   * @param name Optional VCF file base name
-   * @return
-   */
-  @POST
-  @Path("/vcfs")
-  Response addVCF(@Context UriInfo uriInfo, @QueryParam("file") String vcfPath, @QueryParam("name") String name);
-
-  /**
    * Delete a VCF file. Does not fail if such VCF is not found.
    *
    * @param vcfName
@@ -81,17 +68,4 @@ public interface VCFStoreResource {
   @Path("/vcf/{vcfName}")
   Plugins.VCFSummaryDto getVCF(@PathParam("vcfName") String vcfName);
 
-  /**
-   * Download the (compressed) VCF file, optionally encrypted.
-   *
-   * @param vcfName
-   * @param table Table fully qualified name that provides either a Participant or a Sample list, to be used for subsetting the VCF file.
-   * @param withCaseControls
-   * @param fileKey
-   * @return
-   */
-  @GET
-  @Path("/vcf/{vcfName}/_download")
-  Response downloadVCF(@PathParam("vcfName") String vcfName, @QueryParam("table") String table,
-                       @QueryParam("cc") boolean withCaseControls, @HeaderParam("X-File-Key") String fileKey);
 }

--- a/opal-shell/src/main/java/org/obiba/opal/shell/CommandJob.java
+++ b/opal-shell/src/main/java/org/obiba/opal/shell/CommandJob.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
+import com.google.common.base.Strings;
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.session.Session;
 import org.obiba.opal.shell.commands.Command;
@@ -100,7 +101,8 @@ public class CommandJob implements OpalShell, Runnable {
     Session session = SecurityUtils.getSubject().getSession(false);
     if(session != null) session.touch();
     if (percent == 100) {
-      messages.add(createMessage(String.format("%s %s completed.", message, name)));
+      String strMessage = Strings.isNullOrEmpty(message) ? name + " completed." : message;
+      messages.add(createMessage(strMessage));
     }
     messageProgress = message;
     currentProgress = current;

--- a/opal-shell/src/main/java/org/obiba/opal/shell/commands/ExportVCFCommand.java
+++ b/opal-shell/src/main/java/org/obiba/opal/shell/commands/ExportVCFCommand.java
@@ -37,8 +37,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-@CommandUsage(description = "Generate a report based on the specified report template.",
-    syntax = "Syntax: report --project PROJECT --name TEMPLATE")
+@CommandUsage(description = "Export one or more VCF files from a project into a destination folder.",
+    syntax = "Syntax: export-vcf --project PROJECT --destination DESTINATION NAMES")
 public class ExportVCFCommand extends AbstractOpalRuntimeDependentCommand<ExportVCFCommandOptions> {
 
   private static final Logger log = LoggerFactory.getLogger(ExportVCFCommand.class);

--- a/opal-shell/src/main/java/org/obiba/opal/shell/commands/ExportVCFCommand.java
+++ b/opal-shell/src/main/java/org/obiba/opal/shell/commands/ExportVCFCommand.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2017 OBiBa. All rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.obiba.opal.shell.commands;
+
+import com.google.common.base.Stopwatch;
+import com.google.common.base.Strings;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileType;
+import org.obiba.opal.core.domain.Project;
+import org.obiba.opal.core.runtime.NoSuchServiceException;
+import org.obiba.opal.core.runtime.OpalRuntime;
+import org.obiba.opal.core.service.ProjectService;
+import org.obiba.opal.shell.commands.options.ExportVCFCommandOptions;
+import org.obiba.opal.shell.commands.options.ImportVCFCommandOptions;
+import org.obiba.opal.spi.vcf.VCFStore;
+import org.obiba.opal.spi.vcf.VCFStoreException;
+import org.obiba.opal.spi.vcf.VCFStoreService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@CommandUsage(description = "Generate a report based on the specified report template.",
+    syntax = "Syntax: report --project PROJECT --name TEMPLATE")
+public class ExportVCFCommand extends AbstractOpalRuntimeDependentCommand<ExportVCFCommandOptions> {
+
+  private static final Logger log = LoggerFactory.getLogger(ExportVCFCommand.class);
+
+  private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyyMMddHHmmss");
+
+  @Autowired
+  private ProjectService projectService;
+
+  @Autowired
+  private OpalRuntime opalRuntime;
+
+  private VCFStore store;
+
+  //
+  // AbstractOpalRuntimeDependentCommand Methods
+  //
+
+  @Override
+  public int execute() {
+    Stopwatch stopwatch = Stopwatch.createStarted();
+
+    String names = String.join(", ", options.getNames());
+
+    if (options.hasTable())
+      getShell().printf("Exporting VCF files '%s' from project '%s' into '%s', filtered by '%s'...", names, options.getProject(), options.getDestination(), options.getTable());
+    else
+      getShell().printf("Exporting VCF files '%s' from project '%s' into '%s'...", names, options.getProject(), options.getDestination());
+    Project project = projectService.getProject(getOptions().getProject());
+    if (!opalRuntime.hasVCFStoreServices()) throw new NoSuchServiceException(VCFStoreService.SERVICE_TYPE);
+    if (!project.hasVCFStoreService()) {
+      getShell().printf("The project '%s' has no VCF store", options.getProject());
+      return 1;
+    }
+    setVCFStore(project.getVCFStoreService(), project.getName());
+
+    try {
+      exportVCF();
+    } catch (Exception e) {
+      log.error("Cannot export VCF files from project {} into {}: {}", options.getProject(), options.getDestination(), names, e);
+      getShell().printf("Cannot export VCF files: %s", e.getMessage());
+      log.info("Export VCF failed in {}", stopwatch.stop());
+      return 1;
+    }
+
+    log.info("Export VCF succeeded in {}", stopwatch.stop());
+    return 0;
+  }
+
+  //
+  // Methods
+  //
+
+  private void setVCFStore(String serviceName, String name) {
+    if (!opalRuntime.hasVCFStoreServices()) throw new NoSuchElementException("No VCF store service is available");
+    VCFStoreService service = opalRuntime.getVCFStoreService(serviceName);
+    if (!service.hasStore(name)) service.createStore(name);
+    store = service.getStore(name);
+  }
+
+  private void exportVCF() throws IOException, VCFStoreException {
+    FileObject fileObject = resolveFileInFileSystem(options.getDestination());
+    if (fileObject.exists() && fileObject.getType() == FileType.FILE)
+      throw new IllegalArgumentException("Not a valid path to VCF file: " + options.getDestination());
+    if (!fileObject.exists()) fileObject.createFolder();
+    if (!fileObject.isWriteable()) throw new IllegalArgumentException("Export destination is not writable: " + options.getDestination());
+    File destinationFolder = opalRuntime.getFileSystem().getLocalFile(fileObject);
+
+    // TODO samples filtering
+    String timestamp = DATE_FORMAT.format(new Date());
+    int total = options.getNames().size() + 1;
+    getShell().progress(String.format("Exporting VCF file(s): %s", String.join(", ", options.getNames())), 0, total, 0);
+    int count = 1;
+    for (String vcfName : options.getNames()) {
+      getShell().progress(String.format("Exporting VCF file: %s", vcfName), count, total, (count*100)/total);
+      String vcfFileName = vcfName + "-" + timestamp + ".vcf.gz";
+      File vcfFile = new File(destinationFolder, vcfFileName);
+      store.readVCF(vcfName, new FileOutputStream(vcfFile));
+      count++;
+    }
+    getShell().progress(String.format("VCF file(s) export completed."), 3, 3, 100);
+  }
+
+  FileObject resolveFileInFileSystem(String path) throws FileSystemException {
+    if (Strings.isNullOrEmpty(path)) return null;
+    return opalRuntime.getFileSystem().getRoot().resolveFile(path);
+  }
+
+  @Override
+  public String toString() {
+    return "export-vcf -p '" + getOptions().getProject() + "' -d '" + options.getDestination() + "' " + String.join(", ", options.getNames());
+  }
+
+}

--- a/opal-shell/src/main/java/org/obiba/opal/shell/commands/ImportVCFCommand.java
+++ b/opal-shell/src/main/java/org/obiba/opal/shell/commands/ImportVCFCommand.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2017 OBiBa. All rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.obiba.opal.shell.commands;
+
+import com.google.common.base.Stopwatch;
+import com.google.common.base.Strings;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileType;
+import org.obiba.opal.core.domain.Project;
+import org.obiba.opal.core.runtime.NoSuchServiceException;
+import org.obiba.opal.core.runtime.OpalRuntime;
+import org.obiba.opal.core.service.ProjectService;
+import org.obiba.opal.shell.commands.options.ImportVCFCommandOptions;
+import org.obiba.opal.spi.vcf.VCFStore;
+import org.obiba.opal.spi.vcf.VCFStoreException;
+import org.obiba.opal.spi.vcf.VCFStoreService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.NoSuchElementException;
+
+@CommandUsage(description = "Generate a report based on the specified report template.",
+    syntax = "Syntax: report --project PROJECT --name TEMPLATE")
+public class ImportVCFCommand extends AbstractOpalRuntimeDependentCommand<ImportVCFCommandOptions> {
+
+  private static final Logger log = LoggerFactory.getLogger(ImportVCFCommand.class);
+
+  @Autowired
+  private ProjectService projectService;
+
+  @Autowired
+  private OpalRuntime opalRuntime;
+
+  private VCFStore store;
+
+  //
+  // AbstractOpalRuntimeDependentCommand Methods
+  //
+
+  @Override
+  public int execute() {
+    Stopwatch stopwatch = Stopwatch.createStarted();
+
+    getShell().printf("Importing VCF file '%s' located at '%s' in project '%s'...", options.getName(), options.getFile(), options.getProject());
+    getShell().progress(String.format("Preparing VCF file store for project '%s'", options.getProject()), 0, 3, 0);
+    Project project = projectService.getProject(getOptions().getProject());
+    if (!opalRuntime.hasVCFStoreServices()) throw new NoSuchServiceException(VCFStoreService.SERVICE_TYPE);
+    if (!project.hasVCFStoreService()) {
+      // for now get the first one. Some day, the service type will be a project admin choice
+      VCFStoreService service = opalRuntime.getVCFStoreServices().iterator().next();
+      project.setVCFStoreService(service.getName());
+      projectService.save(project);
+    }
+    setVCFStore(project.getVCFStoreService(), project.getName());
+
+    try {
+      importVCF();
+    } catch (Exception e) {
+      log.error("Cannot import VCF {} in project {}: {}", options.getName(), options.getProject(), options.getFile(), e);
+      getShell().printf("Cannot import VCF file: %s", e.getMessage());
+      log.info("Import VCF failed in {}", stopwatch.stop());
+      return 1;
+    }
+
+    log.info("Import VCF succeeded in {}", stopwatch.stop());
+    return 0;
+  }
+
+  //
+  // Methods
+  //
+
+  private void setVCFStore(String serviceName, String name) {
+    if (!opalRuntime.hasVCFStoreServices()) throw new NoSuchElementException("No VCF store service is available");
+    VCFStoreService service = opalRuntime.getVCFStoreService(serviceName);
+    if (!service.hasStore(name)) service.createStore(name);
+    store = service.getStore(name);
+  }
+
+  private void importVCF() throws IOException, VCFStoreException {
+    getShell().progress(String.format("Preparing VCF file '%s'", options.getFile()), 1, 3, 10);
+    FileObject fileObject = resolveFileInFileSystem(options.getFile());
+    if (fileObject == null || !fileObject.exists() || fileObject.getType() == FileType.FOLDER)
+      throw new IllegalArgumentException("Not a valid path to VCF file: " + options.getFile());
+    if (!fileObject.isReadable()) throw new IllegalArgumentException("VCF file is not readable: " + options.getFile());
+    File vcfFile = opalRuntime.getFileSystem().getLocalFile(fileObject);
+    String vcfName = options.getName();
+    if (Strings.isNullOrEmpty(vcfName)) vcfName = vcfFile.getName();
+
+    getShell().progress(String.format("Importing VCF file as '%s'", vcfName), 2, 3, 20);
+    store.writeVCF(vcfName, new FileInputStream(vcfFile));
+    getShell().progress(String.format("VCF file import completed."), 3, 3, 100);
+  }
+
+  FileObject resolveFileInFileSystem(String path) throws FileSystemException {
+    if (Strings.isNullOrEmpty(path)) return null;
+    return opalRuntime.getFileSystem().getRoot().resolveFile(path);
+  }
+
+  @Override
+  public String toString() {
+    return "import-vcf -n '" + getOptions().getName() + "' -p '" + getOptions().getProject() + "' -f '" + options.getFile() + "'";
+  }
+
+}

--- a/opal-shell/src/main/java/org/obiba/opal/shell/commands/ImportVCFCommand.java
+++ b/opal-shell/src/main/java/org/obiba/opal/shell/commands/ImportVCFCommand.java
@@ -31,8 +31,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.NoSuchElementException;
 
-@CommandUsage(description = "Generate a report based on the specified report template.",
-    syntax = "Syntax: report --project PROJECT --name TEMPLATE")
+@CommandUsage(description = "Import VCF file into a project.",
+    syntax = "Syntax: import-vcf --project PROJECT --name NAME --file FILE")
 public class ImportVCFCommand extends AbstractOpalRuntimeDependentCommand<ImportVCFCommandOptions> {
 
   private static final Logger log = LoggerFactory.getLogger(ImportVCFCommand.class);

--- a/opal-shell/src/main/java/org/obiba/opal/shell/commands/options/ExportVCFCommandOptions.java
+++ b/opal-shell/src/main/java/org/obiba/opal/shell/commands/options/ExportVCFCommandOptions.java
@@ -35,4 +35,7 @@ public interface ExportVCFCommandOptions extends HelpOption {
   String getTable();
 
   boolean hasTable();
+
+  @Option(shortName = "c", description = "With case control")
+  boolean isCaseControl();
 }

--- a/opal-shell/src/main/java/org/obiba/opal/shell/commands/options/ExportVCFCommandOptions.java
+++ b/opal-shell/src/main/java/org/obiba/opal/shell/commands/options/ExportVCFCommandOptions.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2017 OBiBa. All rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.obiba.opal.shell.commands.options;
+
+import uk.co.flamingpenguin.jewel.cli.CommandLineInterface;
+import uk.co.flamingpenguin.jewel.cli.Option;
+import uk.co.flamingpenguin.jewel.cli.Unparsed;
+
+import java.util.List;
+
+/**
+ * This interface declares the options that may be used with the import VCF command.
+ */
+@CommandLineInterface(application = "export-vcf")
+public interface ExportVCFCommandOptions extends HelpOption {
+
+  @Unparsed(name = "NAME")
+  List<String> getNames();
+
+  @Option(shortName = "p", description = "The project associated to the VCF store.")
+  String getProject();
+
+  @Option(shortName = "d", description = "The destination folder.")
+  String getDestination();
+
+  @Option(shortName = "t", description = "The optional table reference to be used to subset samples.")
+  String getTable();
+
+  boolean hasTable();
+}

--- a/opal-shell/src/main/java/org/obiba/opal/shell/commands/options/ImportVCFCommandOptions.java
+++ b/opal-shell/src/main/java/org/obiba/opal/shell/commands/options/ImportVCFCommandOptions.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2017 OBiBa. All rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.obiba.opal.shell.commands.options;
+
+import uk.co.flamingpenguin.jewel.cli.CommandLineInterface;
+import uk.co.flamingpenguin.jewel.cli.Option;
+
+/**
+ * This interface declares the options that may be used with the import VCF command.
+ */
+@CommandLineInterface(application = "import-vcf")
+public interface ImportVCFCommandOptions extends HelpOption {
+
+  @Option(shortName = "n", description = "The VCF file name.")
+  String getName();
+
+  @Option(shortName = "p", description = "The project associated to the VCF store.")
+  String getProject();
+
+  @Option(shortName = "f", description = "The VCF file location.")
+  String getFile();
+}

--- a/opal-shell/src/main/java/org/obiba/opal/shell/web/ExportVCFCommandOptionsDtoImpl.java
+++ b/opal-shell/src/main/java/org/obiba/opal/shell/web/ExportVCFCommandOptionsDtoImpl.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2017 OBiBa. All rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.obiba.opal.shell.web;
+
+import org.obiba.opal.shell.commands.options.ExportVCFCommandOptions;
+import org.obiba.opal.web.model.Commands;
+
+import java.util.List;
+
+public class ExportVCFCommandOptionsDtoImpl implements ExportVCFCommandOptions {
+
+  private final Commands.ExportVCFCommandOptionsDto options;
+
+  public ExportVCFCommandOptionsDtoImpl(Commands.ExportVCFCommandOptionsDto options) {
+    this.options = options;
+  }
+
+  @Override
+  public boolean isHelp() {
+    return false;
+  }
+
+  @Override
+  public List<String> getNames() {
+    return options.getNamesList();
+  }
+
+  @Override
+  public String getProject() {
+    return options.getProject();
+  }
+
+  @Override
+  public String getDestination() {
+    return options.getDestination();
+  }
+
+  @Override
+  public String getTable() {
+    return options.hasTable() ? options.getTable() : "";
+  }
+
+  @Override
+  public boolean hasTable() {
+    return options.hasTable();
+  }
+}

--- a/opal-shell/src/main/java/org/obiba/opal/shell/web/ExportVCFCommandOptionsDtoImpl.java
+++ b/opal-shell/src/main/java/org/obiba/opal/shell/web/ExportVCFCommandOptionsDtoImpl.java
@@ -52,4 +52,9 @@ public class ExportVCFCommandOptionsDtoImpl implements ExportVCFCommandOptions {
   public boolean hasTable() {
     return options.hasTable();
   }
+
+  @Override
+  public boolean isCaseControl() {
+    return options.hasCaseControl() ? options.getCaseControl() : true;
+  }
 }

--- a/opal-shell/src/main/java/org/obiba/opal/shell/web/ImportVCFCommandOptionsDtoImpl.java
+++ b/opal-shell/src/main/java/org/obiba/opal/shell/web/ImportVCFCommandOptionsDtoImpl.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2017 OBiBa. All rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.obiba.opal.shell.web;
+
+import org.obiba.opal.shell.commands.options.ImportVCFCommandOptions;
+import org.obiba.opal.web.model.Commands;
+
+public class ImportVCFCommandOptionsDtoImpl implements ImportVCFCommandOptions {
+
+  private final Commands.ImportVCFCommandOptionsDto options;
+
+  public ImportVCFCommandOptionsDtoImpl(Commands.ImportVCFCommandOptionsDto options) {
+    this.options = options;
+  }
+
+  @Override
+  public boolean isHelp() {
+    return false;
+  }
+
+  @Override
+  public String getName() {
+    return options.getName();
+  }
+
+  @Override
+  public String getProject() {
+    return options.getProject();
+  }
+
+  @Override
+  public String getFile() {
+    return options.getFile();
+  }
+}

--- a/opal-shell/src/main/java/org/obiba/opal/shell/web/WebShellCommandRegistry.java
+++ b/opal-shell/src/main/java/org/obiba/opal/shell/web/WebShellCommandRegistry.java
@@ -10,12 +10,8 @@
 package org.obiba.opal.shell.web;
 
 import org.obiba.opal.shell.AbstractCommandRegistry;
-import org.obiba.opal.shell.commands.CopyCommand;
-import org.obiba.opal.shell.commands.ImportCommand;
-import org.obiba.opal.shell.commands.ReportCommand;
-import org.obiba.opal.shell.commands.options.CopyCommandOptions;
-import org.obiba.opal.shell.commands.options.ImportCommandOptions;
-import org.obiba.opal.shell.commands.options.ReportCommandOptions;
+import org.obiba.opal.shell.commands.*;
+import org.obiba.opal.shell.commands.options.*;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -32,5 +28,7 @@ public class WebShellCommandRegistry extends AbstractCommandRegistry {
     addAvailableCommand(CopyCommand.class, CopyCommandOptions.class);
     addAvailableCommand("export", CopyCommand.class, CopyCommandOptions.class);
     addAvailableCommand(ReportCommand.class, ReportCommandOptions.class);
+    addAvailableCommand(ImportVCFCommand.class, ImportVCFCommandOptions.class);
+    addAvailableCommand(ExportVCFCommand.class, ExportVCFCommandOptions.class);
   }
 }

--- a/opal-shell/src/main/java/org/obiba/opal/web/shell/ProjectCommandsResource.java
+++ b/opal-shell/src/main/java/org/obiba/opal/web/shell/ProjectCommandsResource.java
@@ -26,13 +26,8 @@ import org.obiba.opal.shell.CommandJob;
 import org.obiba.opal.shell.CommandRegistry;
 import org.obiba.opal.shell.Dtos;
 import org.obiba.opal.shell.commands.Command;
-import org.obiba.opal.shell.commands.options.CopyCommandOptions;
-import org.obiba.opal.shell.commands.options.ImportCommandOptions;
-import org.obiba.opal.shell.commands.options.ReportCommandOptions;
-import org.obiba.opal.shell.web.CopyCommandOptionsDtoImpl;
-import org.obiba.opal.shell.web.ExportCommandOptionsDtoImpl;
-import org.obiba.opal.shell.web.ImportCommandOptionsDtoImpl;
-import org.obiba.opal.shell.web.ReportCommandOptionsDtoImpl;
+import org.obiba.opal.shell.commands.options.*;
+import org.obiba.opal.shell.web.*;
 import org.obiba.opal.web.model.Commands;
 import org.obiba.opal.web.support.InvalidRequestException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -70,6 +65,10 @@ public class ProjectCommandsResource extends AbstractCommandsResource {
 
     return commandDtoList;
   }
+
+  //
+  // Phenotype data
+  //
 
   @POST
   @Path("/_import")
@@ -126,6 +125,32 @@ public class ProjectCommandsResource extends AbstractCommandsResource {
 
     return launchCommand(commandName, copyCommand);
   }
+
+  //
+  // Genotype data
+  //
+
+  @POST
+  @Path("/_import_vcf")
+  public Response importVCF(Commands.ImportVCFCommandOptionsDto optionsDto) {
+    ImportVCFCommandOptions options = new ImportVCFCommandOptionsDtoImpl(optionsDto);
+    Command<ImportVCFCommandOptions> command = commandRegistry.newCommand("import-vcf");
+    command.setOptions(options);
+    return launchCommand(command);
+  }
+
+  @POST
+  @Path("/_export_vcf")
+  public Response exportVCF(Commands.ExportVCFCommandOptionsDto optionsDto) {
+    ExportVCFCommandOptions options = new ExportVCFCommandOptionsDtoImpl(optionsDto);
+    Command<ExportVCFCommandOptions> command = commandRegistry.newCommand("export-vcf");
+    command.setOptions(options);
+    return launchCommand(command);
+  }
+
+  //
+  // Report
+  //
 
   @POST
   @Path("/_report")

--- a/opal-web-model/src/main/protobuf/Commands.proto
+++ b/opal-web-model/src/main/protobuf/Commands.proto
@@ -94,4 +94,5 @@ message ExportVCFCommandOptionsDto {
   required string project = 2; // store location
   required string destination = 3; // Destination folder
   optional string table = 4; // table reference to be used for sample subseting
+  optional bool caseControl = 5 [default = true];
 }

--- a/opal-web-model/src/main/protobuf/Commands.proto
+++ b/opal-web-model/src/main/protobuf/Commands.proto
@@ -82,3 +82,16 @@ message ReportCommandOptionsDto {
   required string name = 1;
   required string project = 2;
 }
+
+message ImportVCFCommandOptionsDto {
+  required string name = 1; // VCF file name in the store
+  required string project = 2; // store location
+  required string file = 3; // VCF file location
+}
+
+message ExportVCFCommandOptionsDto {
+  repeated string names = 1; // VCF file names
+  required string project = 2; // store location
+  required string destination = 3; // Destination folder
+  optional string table = 4; // table reference to be used for sample subseting
+}


### PR DESCRIPTION
Direct import and download is not possible any more. This allows to handle long running tasks and  simplifies the file download code (encryption).