### PR TITLE
OPAL-2866 Removed filter method from VCFStore as it is redundant with…

### DIFF
--- a/opal-spi/src/main/java/org/obiba/opal/spi/vcf/VCFStore.java
+++ b/opal-spi/src/main/java/org/obiba/opal/spi/vcf/VCFStore.java
@@ -129,16 +129,6 @@ public interface VCFStore {
   void readVCFStatistics(String name, OutputStream out) throws NoSuchElementException, IOException;
 
   /**
-   * Filter the stored VCF with the given name, with a provided comma-separated list of samples. The result is a compressed file placed in the destination file.
-   *
-   * @param vcfName
-   * @param format
-   * @param commaSeparatedSampleIds
-   * @param destination
-   */
-  void filter(String vcfName, Format format, String commaSeparatedSampleIds, File destination) throws NoSuchElementException, IOException;
-
-  /**
    * VCF file format flavor.
    */
   enum Format {


### PR DESCRIPTION
… readVCF (and having thousands of sample Ids on the command line could lead to some problems)