### PR TITLE
Revert "OPAL-2866 - export check if a filtering table is selected or control …"

### DIFF
--- a/opal-core-api/src/main/java/org/obiba/opal/core/service/VCFSamplesMappingService.java
+++ b/opal-core-api/src/main/java/org/obiba/opal/core/service/VCFSamplesMappingService.java
@@ -19,7 +19,5 @@ public interface VCFSamplesMappingService extends SystemService {
 
   void delete(@NotNull String name) throws NoSuchVCFSamplesMappingException;
 
-  List<String> getFilteredSampleIds(@NotNull String projectName, String filteringTable, boolean withControl);
-
-  List<String> getControls(@NotNull String projectName);
+  List<String> getFilteredSampleIds(@NotNull String projectName, @NotNull String filteringTable, boolean withControl);
 }

--- a/opal-core/src/main/java/org/obiba/opal/core/service/VCFSamplesMappingServiceImpl.java
+++ b/opal-core/src/main/java/org/obiba/opal/core/service/VCFSamplesMappingServiceImpl.java
@@ -1,7 +1,5 @@
 package org.obiba.opal.core.service;
 
-import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
 import org.obiba.magma.ValueSet;
 import org.obiba.magma.ValueTable;
 import org.obiba.magma.VariableEntity;
@@ -70,27 +68,14 @@ public class VCFSamplesMappingServiceImpl implements VCFSamplesMappingService {
   }
 
   @Override
-  public List<String> getFilteredSampleIds(@NotNull String projectName, String filteringTable, boolean withControl) {
-    List<String> participantIds = Strings.isNullOrEmpty(filteringTable) ? 
-        Lists.newArrayList() :
-        MagmaEngineTableResolver.valueOf(filteringTable).resolveTable()
-            .getVariableEntities().stream().map(VariableEntity::getIdentifier).collect(Collectors.toList());
+  public List<String> getFilteredSampleIds(@NotNull String projectName, @NotNull String filteringTable, boolean withControl) {
+    ValueTable filteringValueTable = MagmaEngineTableResolver.valueOf(filteringTable).resolveTable();
+    List<String> participantIds = filteringValueTable.getVariableEntities().stream().map(VariableEntity::getIdentifier).collect(Collectors.toList());
 
     Map<String, ParticipantRolePair> sampleParticipantMap = getSampleParticipantMap(projectName);
     return sampleParticipantMap.entrySet()
         .stream()
-        .filter(e -> (e.getValue().getKey() == null && VCFSampleRole.isControl(e.getValue().getValue()) && withControl) ||
-            participantIds.contains(e.getValue().getKey())
-        )
-        .map(Map.Entry::getKey).collect(Collectors.toList());
-  }
-
-  @Override
-  public List<String> getControls(@NotNull String projectName) {
-    Map<String, ParticipantRolePair> sampleParticipantMap = getSampleParticipantMap(projectName);
-    return sampleParticipantMap.entrySet()
-        .stream()
-        .filter(e -> VCFSampleRole.isControl(e.getValue().getValue()))
+        .filter(e -> (e.getValue().getKey() == null && VCFSampleRole.isControl(e.getValue().getValue()) && withControl) || participantIds.contains(e.getValue().getKey()))
         .map(Map.Entry::getKey).collect(Collectors.toList());
   }
 

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/project/genotypes/ProjectExportVcfFileModalView.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/project/genotypes/ProjectExportVcfFileModalView.java
@@ -122,7 +122,6 @@ public class ProjectExportVcfFileModalView extends ModalPopupViewWithUiHandlers<
 
   @Override
   public void showMappingDependant(boolean show) {
-    includeCaseControls.setValue(show);
     mappingDependant.setVisible(show);
   }
 

--- a/opal-shell/src/main/java/org/obiba/opal/shell/commands/ExportVCFCommand.java
+++ b/opal-shell/src/main/java/org/obiba/opal/shell/commands/ExportVCFCommand.java
@@ -122,9 +122,7 @@ public class ExportVCFCommand extends AbstractOpalRuntimeDependentCommand<Export
 
     List<String> filterSampleIds = options.hasTable() ?
         vcfSamplesMappingService.getFilteredSampleIds(options.getProject(), options.getTable(), options.isCaseControl()) :
-        !options.hasTable() && !options.isCaseControl() ?
-            vcfSamplesMappingService.getControls(options.getProject()) :
-            Lists.newArrayList();
+        Lists.newArrayList();
 
     int count = 1;
     for (String vcfName : options.getNames()) {
@@ -133,10 +131,8 @@ public class ExportVCFCommand extends AbstractOpalRuntimeDependentCommand<Export
       String vcfFileName = vcfName + "." + summary.getFormat().name().toLowerCase() + ".gz";
       getShell().printf(String.format("Exporting VCF/BCF file: %s", vcfFileName));
       File vcfFile = new File(destinationFolder, vcfFileName);
-      if (!options.hasTable() && filterSampleIds.isEmpty())
+      if (filterSampleIds.isEmpty())
         store.readVCF(vcfName, new FileOutputStream(vcfFile));
-      else if (!options.hasTable() && !options.isCaseControl())
-        store.readVCF(vcfName, new FileOutputStream(vcfFile), filterSampleIds, false);
       else
         store.readVCF(vcfName, new FileOutputStream(vcfFile), filterSampleIds);
       count++;

--- a/opal-spi/src/main/java/org/obiba/opal/spi/vcf/VCFStore.java
+++ b/opal-spi/src/main/java/org/obiba/opal/spi/vcf/VCFStore.java
@@ -106,17 +106,6 @@ public interface VCFStore {
    */
   void readVCF(String name, OutputStream out, Collection<String> samples) throws NoSuchElementException, IOException;
 
-  /**
-   * Read the VCF stored with the given name, with a subset applied to the provided samples. The returned stream is a compressed VCF file.
-   *
-   * @param name
-   * @param out The stream to write to.
-   * @param samples The sample IDs.
-   * @param includeSamples Whether to include or exclude the sample IDs.
-   * @throws NoSuchElementException
-   * @throws IOException
-   */
-  void readVCF(String name, OutputStream out, Collection<String> samples, boolean includeSamples) throws NoSuchElementException, IOException;
 
   /**
    * Read the VCF stored with the given name, with a subset applied to the provided samples. The returned stream is a compressed VCF file.
@@ -128,19 +117,6 @@ public interface VCFStore {
    * @return
    */
   void readVCF(String name, Format format, OutputStream out, Collection<String> samples) throws NoSuchElementException, IOException;
-
-  /**
-   * Read the VCF stored with the given name, with a subset applied to the provided samples. The returned stream is a compressed VCF file.
-   *
-   * @param vcfName
-   * @param format
-   * @param out The stream to write to.
-   * @param samples The sample IDs.
-   * @param includeSamples Whether to include or exclude the sample IDs.
-   * @throws NoSuchElementException
-   * @throws IOException
-   */
-  void readVCF(String vcfName, Format format, OutputStream out, Collection<String> samples, boolean includeSamples) throws NoSuchElementException, IOException;
 
 
   /**


### PR DESCRIPTION
Reverts obiba/opal#769 because you were not supposed to overload the VCF store API: just pass the appropriate list of samples.