### PR TITLE
OPAL-2888 - enclose a project's orientdb save in a synchronized block

### DIFF
--- a/opal-core/src/main/java/org/obiba/opal/core/service/ProjectsServiceImpl.java
+++ b/opal-core/src/main/java/org/obiba/opal/core/service/ProjectsServiceImpl.java
@@ -170,7 +170,10 @@ public class ProjectsServiceImpl implements ProjectService {
     } catch(NoSuchProjectException e) {
       registerDatasource(project);
     }
-    orientDbService.save(project, project);
+
+    synchronized (this) {
+      orientDbService.save(project, project);
+    }
   }
 
   @NotNull


### PR DESCRIPTION
orientdb's transaction type is currently set to optimistic, meaning there is not much checks for other transactions or locks. The only other options are "no transaction" or a pessimistic transaction. The latter is not yet supported (version 2.2.x, we are on 2.1.x).

We can either do this change for only projects or do a general change and make the orientdb service's save method synchronized.