### PR TITLE
OPAL-2914 - show vcf store section in a project's administration page

### DIFF
--- a/opal-core-ws/src/main/java/org/obiba/opal/web/project/ProjectResource.java
+++ b/opal-core-ws/src/main/java/org/obiba/opal/web/project/ProjectResource.java
@@ -132,14 +132,7 @@ public class ProjectResource {
   public VCFStoreResource getVCFStoreResource() {
     Project project = getProject();
     if (!opalRuntime.hasServicePlugins(VCFStoreService.class)) throw new NoSuchServiceException(VCFStoreService.SERVICE_TYPE);
-    if (!project.hasVCFStoreService()) {
-      if (opalRuntime.getServicePlugins(VCFStoreService.class).size() == 1) {
-        // set the unique VCF store service automatically
-        ServicePlugin service = opalRuntime.getServicePlugins(VCFStoreService.class).stream().iterator().next();
-        project.setVCFStoreService(service.getName());
-        projectService.save(project);
-      } else throw new IllegalArgumentException("Project has no VCF store: " + project.getName());
-    }
+    if (!project.hasVCFStoreService()) throw new IllegalArgumentException("Project has no VCF store: " + project.getName());
     VCFStoreResource resource = applicationContext.getBean(VCFStoreResource.class);
     resource.setVCFStore(project.getVCFStoreService(), name);
     return resource;

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/project/genotypes/ProjectGenotypesPresenter.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/project/genotypes/ProjectGenotypesPresenter.java
@@ -163,9 +163,8 @@ public class ProjectGenotypesPresenter extends PresenterWidget<ProjectGenotypesP
     if (dto.hasVcfStoreService()) {
       getParticipantTables();
       refresh();
+      authorize();
     }
-
-    authorize();
   }
 
   @Override
@@ -283,9 +282,8 @@ public class ProjectGenotypesPresenter extends PresenterWidget<ProjectGenotypesP
   }
 
   public void refresh() {
-    getVcfStore();
+    onRefresh();
     getMappingTable();
-    getVcfSummaries();
   }
 
   private void authorize() {

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/project/view/ProjectPresenter.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/project/view/ProjectPresenter.java
@@ -157,8 +157,6 @@ public class ProjectPresenter extends Presenter<ProjectPresenter.Display, Projec
 
   private BookmarkIconPresenter bookmarkIconPresenter;
 
-  private boolean hasServicePlugins = false;
-
   @Inject
   @SuppressWarnings({ "PMD.ExcessiveParameterList", "ConstructorWithTooManyParameters" })
   public ProjectPresenter(EventBus eventBus, Display display, Proxy proxy, PlaceManager placeManager,
@@ -366,7 +364,7 @@ public class ProjectPresenter extends Presenter<ProjectPresenter.Display, Projec
       projectAdministrationPresenter = projectAdministrationPresenterProvider.get();
       setInSlot(ADMIN_PANE, projectAdministrationPresenter);
     }
-    projectAdministrationPresenter.setProject(project, hasServicePlugins);
+    projectAdministrationPresenter.setProject(project);
   }
 
   @Override

--- a/opal-shell/src/main/java/org/obiba/opal/shell/commands/ImportVCFCommand.java
+++ b/opal-shell/src/main/java/org/obiba/opal/shell/commands/ImportVCFCommand.java
@@ -58,14 +58,7 @@ public class ImportVCFCommand extends AbstractOpalRuntimeDependentCommand<Import
     getShell().progress(String.format("Preparing VCF file store for project '%s'", options.getProject()), 0, 3, 0);
     Project project = projectService.getProject(options.getProject());
     if (!opalRuntime.hasServicePlugins(VCFStoreService.class)) throw new NoSuchServiceException(VCFStoreService.SERVICE_TYPE);
-    if (!project.hasVCFStoreService()) {
-      if (opalRuntime.getServicePlugins(VCFStoreService.class).size() == 1) {
-        // set the unique VCF store service automatically
-        ServicePlugin service = opalRuntime.getServicePlugins(VCFStoreService.class).stream().iterator().next();
-        project.setVCFStoreService(service.getName());
-        projectService.save(project);
-      } else throw new IllegalArgumentException("Project has no VCF store: " + options.getProject());
-    }
+    if (!project.hasVCFStoreService()) throw new IllegalArgumentException("Project has no VCF store: " + options.getProject());
     setVCFStore(project.getVCFStoreService(), project.getName());
 
     try {

--- a/opal-ws/src/main/java/org/obiba/opal/web/services/PluginsResource.java
+++ b/opal-ws/src/main/java/org/obiba/opal/web/services/PluginsResource.java
@@ -42,7 +42,7 @@ public class PluginsResource {
   @NoAuthorization
   public List<Plugins.PluginDto> get(@QueryParam("type") String type) {
     return opalRuntime.getPlugins().stream()
-        .map(Dtos::asDto)
+        .map(Dtos::asDtoForPublic)
         .filter(p -> Strings.isNullOrEmpty(type) || (type.equals(p.getType())))
         .collect(Collectors.toList());
   }


### PR DESCRIPTION
A call to /plugins should no longer set the "custom" properties.

I also removed the "auto add vcf store service" to a project because the authorizer seems to add a vcf-store automatically and this change is not reflected in the UI.

Another change for this would be to refresh the project on every tab.