### PR TITLE
Updated findbugs maven plugin dependency version to 3.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1859,7 +1859,7 @@
     <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
     <maven-deploy-plugin.version>2.8.1</maven-deploy-plugin.version>
     <maven.enforcer.plugin>1.2</maven.enforcer.plugin>
-    <maven-findbugs-plugin.version>2.5.3</maven-findbugs-plugin.version>
+    <maven-findbugs-plugin.version>3.0.4</maven-findbugs-plugin.version>
     <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
     <maven-javacc-plugin.version>2.6</maven-javacc-plugin.version>
     <maven-javadoc-plugin.version>2.9.1</maven-javadoc-plugin.version>


### PR DESCRIPTION
Jsr305 annotation dependency is still at 2.0.3, newest version is 3.0.2 (March 2017).