### PR TITLE
Improvement/refresh project

### DIFF
--- a/opal-core-api/src/main/java/org/obiba/opal/core/domain/Project.java
+++ b/opal-core-api/src/main/java/org/obiba/opal/core/domain/Project.java
@@ -53,8 +53,7 @@ public class Project extends AbstractTimestamped implements HasUniqueProperties,
 
   private String exportFolder;
 
-  public Project() {
-  }
+  public Project() { }
 
   public Project(@NotNull String name) {
     this.name = name;

--- a/opal-core-api/src/main/java/org/obiba/opal/core/service/ProjectService.java
+++ b/opal-core-api/src/main/java/org/obiba/opal/core/service/ProjectService.java
@@ -35,7 +35,7 @@ public interface ProjectService extends SystemService {
   /**
    * Get project directory, create it if it does not exist.
    *
-   * @param name
+   * @param project
    * @return
    * @throws NoSuchIdentifiersMappingException
    * @throws FileSystemException

--- a/opal-core-api/src/main/java/org/obiba/opal/web/support/ConflictingRequestException.java
+++ b/opal-core-api/src/main/java/org/obiba/opal/web/support/ConflictingRequestException.java
@@ -1,0 +1,24 @@
+package org.obiba.opal.web.support;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ConflictingRequestException extends RuntimeException {
+
+  private final List<String> messageArgs;
+
+  public ConflictingRequestException(String message, String... messageArgs) {
+    super(message);
+
+    this.messageArgs = new ArrayList<>();
+
+    if(messageArgs != null) {
+      Collections.addAll(this.messageArgs, messageArgs);
+    }
+  }
+
+  public List<String> getMessageArgs() {
+    return Collections.unmodifiableList(messageArgs);
+  }
+}

--- a/opal-core-ws/src/main/java/org/obiba/opal/core/security/DatasourcePermissionConverter.java
+++ b/opal-core-ws/src/main/java/org/obiba/opal/core/security/DatasourcePermissionConverter.java
@@ -73,6 +73,7 @@ public class DatasourcePermissionConverter extends OpalPermissionConverter {
             toRest("/project/{0}/commands/_import", "POST:GET", args),//
             toRest("/project/{0}/commands/_export", "POST:GET", args),//
             toRest("/project/{0}/commands/_copy", "POST:GET", args),//
+            toRest("/project/{0}/commands/_refresh", "POST:GET", args),//
             toRest("/files/projects/{0}", "GET:GET/*", args), //
             toRest("/files/projects/{0}", "POST:GET/*", args), //
             toRest("/files/projects/{0}", "PUT:GET/*", args));
@@ -86,6 +87,7 @@ public class DatasourcePermissionConverter extends OpalPermissionConverter {
             toRest("/project/{0}/commands/_analyse", "POST:GET", args),//
             toRest("/project/{0}/commands/_export", "POST:GET", args),//
             toRest("/project/{0}/commands/_copy", "POST:GET", args),//
+            toRest("/project/{0}/commands/_refresh", "POST:GET", args),//
             toRest("/project/{0}/report-templates", "GET:GET", args),//
             toRest("/project/{0}/report-templates", "POST:GET", args),//
             toRest("/project/{0}", "GET:GET", args),//

--- a/opal-core-ws/src/main/java/org/obiba/opal/core/security/TablePermissionConverter.java
+++ b/opal-core-ws/src/main/java/org/obiba/opal/core/security/TablePermissionConverter.java
@@ -48,6 +48,7 @@ public class TablePermissionConverter extends OpalPermissionConverter {
         List<String> perms = Lists.newArrayList(toRest("/datasource/{0}/table/{1}", "*:GET/*", args),//
             toRest("/project/{0}/commands/_export", "POST:GET", args),//
             toRest("/project/{0}/commands/_copy", "POST:GET", args),//
+            toRest("/project/{0}/commands/_refresh", "POST:GET", args),//
             toRest("/project/{0}/report-templates", "GET:GET", args),//
             toRest("/project/{0}/report-templates", "POST:GET", args),//
             toRest("/project/{0}", "GET:GET", args),//
@@ -101,6 +102,7 @@ public class TablePermissionConverter extends OpalPermissionConverter {
             toRest("/project/{0}/commands/_analyse", "POST:GET", args),//
             toRest("/project/{0}/commands/_export", "POST:GET", args),//
             toRest("/project/{0}/commands/_copy", "POST:GET", args),//
+            toRest("/project/{0}/commands/_refresh", "POST:GET", args),//
             toRest("/project/{0}/report-templates", "GET:GET", args),//
             toRest("/project/{0}/report-templates", "POST:GET", args),//
             toRest("/project/{0}", "GET:GET", args),//

--- a/opal-core-ws/src/main/java/org/obiba/opal/web/provider/ConflictingRequestExceptionMapper.java
+++ b/opal-core-ws/src/main/java/org/obiba/opal/web/provider/ConflictingRequestExceptionMapper.java
@@ -1,0 +1,18 @@
+package org.obiba.opal.web.provider;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+import org.obiba.opal.web.support.ConflictingRequestException;
+import org.springframework.stereotype.Component;
+
+@Component
+@Provider
+public class ConflictingRequestExceptionMapper implements ExceptionMapper<ConflictingRequestException> {
+
+  @Override
+  public Response toResponse(ConflictingRequestException exception) {
+    return Response.status(Status.CONFLICT).build();
+  }
+}

--- a/opal-core-ws/src/test/java/org/obiba/opal/core/security/DatasourcePermissionConverterTest.java
+++ b/opal-core-ws/src/test/java/org/obiba/opal/core/security/DatasourcePermissionConverterTest.java
@@ -43,6 +43,7 @@ public class DatasourcePermissionConverterTest
         "rest:/project/patate/commands/_analyse:POST:GET", //
         "rest:/project/patate/commands/_export:POST:GET", //
         "rest:/project/patate/commands/_copy:POST:GET", //
+        "rest:/project/patate/commands/_refresh:POST:GET", //
         "rest:/project/patate/report-templates:GET:GET", //
         "rest:/project/patate/report-templates:POST:GET", //
         "rest:/project/patate:GET:GET", //
@@ -66,6 +67,7 @@ public class DatasourcePermissionConverterTest
         "rest:/project/patate/commands/_import:POST:GET", //
         "rest:/project/patate/commands/_export:POST:GET", //
         "rest:/project/patate/commands/_copy:POST:GET", //
+        "rest:/project/patate/commands/_refresh:POST:GET", //
         "rest:/files/projects/patate:GET:GET/*", //
         "rest:/files/projects/patate:POST:GET/*",//
         "rest:/files/projects/patate:PUT:GET/*");

--- a/opal-core-ws/src/test/java/org/obiba/opal/core/security/TablePermissionConverterTest.java
+++ b/opal-core-ws/src/test/java/org/obiba/opal/core/security/TablePermissionConverterTest.java
@@ -33,6 +33,7 @@ public class TablePermissionConverterTest extends OpalPermissionConverterTest<Ta
         "rest:/datasource/patate/table/pwel:*:GET/*", //
         "rest:/project/patate/commands/_export:POST:GET", //
         "rest:/project/patate/commands/_copy:POST:GET", //
+        "rest:/project/patate/commands/_refresh:POST:GET", //
         "rest:/project/patate/report-templates:GET:GET", //
         "rest:/project/patate/report-templates:POST:GET", //
         "rest:/project/patate:GET:GET", //
@@ -49,6 +50,7 @@ public class TablePermissionConverterTest extends OpalPermissionConverterTest<Ta
         "rest:/datasource/patate/table/pwel:*:GET/*", //
         "rest:/project/patate/commands/_export:POST:GET", //
         "rest:/project/patate/commands/_copy:POST:GET", //
+        "rest:/project/patate/commands/_refresh:POST:GET", //
         "rest:/project/patate/report-templates:GET:GET", //
         "rest:/project/patate/report-templates:POST:GET", //
         "rest:/project/patate:GET:GET", //
@@ -95,6 +97,7 @@ public class TablePermissionConverterTest extends OpalPermissionConverterTest<Ta
         "rest:/project/patate/commands/_analyse:POST:GET", //
         "rest:/project/patate/commands/_export:POST:GET", //
         "rest:/project/patate/commands/_copy:POST:GET", //
+        "rest:/project/patate/commands/_refresh:POST:GET", //
         "rest:/project/patate/report-templates:GET:GET", //
         "rest:/project/patate/report-templates:POST:GET", //
         "rest:/project/patate:GET:GET", //
@@ -161,6 +164,7 @@ public class TablePermissionConverterTest extends OpalPermissionConverterTest<Ta
         "rest:/project/patate/commands/_analyse:POST:GET", //
         "rest:/project/patate/commands/_export:POST:GET", //
         "rest:/project/patate/commands/_copy:POST:GET", //
+        "rest:/project/patate/commands/_refresh:POST:GET", //
         "rest:/project/patate/report-templates:GET:GET", //
         "rest:/project/patate/report-templates:POST:GET", //
         "rest:/project/patate:GET:GET", //

--- a/opal-core/src/main/java/org/obiba/opal/core/service/ProjectsServiceImpl.java
+++ b/opal-core/src/main/java/org/obiba/opal/core/service/ProjectsServiceImpl.java
@@ -209,14 +209,7 @@ public class ProjectsServiceImpl implements ProjectService {
     }
   }
 
-  /**
-   * Create DatasourceFactory and add it to MagmaEngine
-   *
-   * @param project
-   * @return
-   */
-  @NotNull
-  private DatasourceFactory registerDatasource(@NotNull final Project project) {
+  public static DatasourceFactory registerDatasource(final Project project, final TransactionTemplate transactionTemplate, final DatabaseRegistry databaseRegistry) {
     return transactionTemplate.execute(new TransactionCallback<DatasourceFactory>() {
       @Override
       public DatasourceFactory doInTransaction(TransactionStatus status) {
@@ -232,6 +225,17 @@ public class ProjectsServiceImpl implements ProjectService {
         return dataSourceFactory;
       }
     });
+  }
+
+  /**
+   * Create DatasourceFactory and add it to MagmaEngine
+   *
+   * @param project
+   * @return
+   */
+  @NotNull
+  private DatasourceFactory registerDatasource(@NotNull final Project project) {
+    return registerDatasource(project, transactionTemplate, databaseRegistry);
   }
 
   private void deleteFolder(FileObject folder) throws FileSystemException {

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/i18n/TranslationMessages.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/i18n/TranslationMessages.java
@@ -76,6 +76,10 @@ public interface TranslationMessages extends Messages {
   @DefaultMessage("Archive Project")
   String archiveProject();
 
+  @Description("Refresh Project label")
+  @DefaultMessage("Refresh Project")
+  String refreshProject();
+
   @Description("Remove Datasource label")
   @DefaultMessage("Remove Datasource")
   String removeDatasource();
@@ -324,6 +328,11 @@ public interface TranslationMessages extends Messages {
       "Please confirm that you want to remove the current project and keep all associated data message.")
   @DefaultMessage("Please confirm that you want to remove the current project and keep all associated data.")
   String confirmArchiveProject();
+
+  @Description(
+      "Please confirm that you want to refresh the current project message.")
+  @DefaultMessage("Please confirm that you want to refresh the current project.")
+  String confirmRefreshProject();
 
   @Description("Please confirm that you want to remove the current datasource from Opal configuration message")
   @DefaultMessage("Please confirm that you want to remove the current datasource from Opal configuration")

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/i18n/Translations.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/i18n/Translations.java
@@ -397,6 +397,7 @@ public interface Translations extends Constants {
       "InternalError", "An internal error has occurred. Please contact technical support.", //
       "UnhandledException",
       "An internal error has occurred. Please contact technical support and provide the following system error:<br /><br /><pre>{0}</pre>",
+      "ProjectMomentarilyNotRefreshable", "Project [{0}]'s command call is blocked momentarily.",
       //
       "DatasourceNameDisallowedChars", "Project names cannot contain colon or period characters.", //
       "ViewNameDisallowedChars", "View names cannot contain colon or period characters.", //

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/presenter/DatasourcePresenter.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/presenter/DatasourcePresenter.java
@@ -297,6 +297,7 @@ public class DatasourcePresenter extends PresenterWidget<DatasourcePresenter.Dis
     private void displayDatasource(DatasourceDto datasourceDto) {
       getView().setDatasource(datasourceDto);
       updateTables();
+      initProjectCommandsState();
       authorize();
     }
 
@@ -324,6 +325,18 @@ public class DatasourcePresenter extends PresenterWidget<DatasourcePresenter.Dis
               getView().afterRenderRows();
             }
           }, Response.SC_BAD_REQUEST, Response.SC_INTERNAL_SERVER_ERROR, Response.SC_NOT_FOUND, Response.SC_FORBIDDEN).send();
+    }
+
+    private void initProjectCommandsState() {
+      ResourceRequestBuilderFactory.newBuilder()
+          .forResource(UriBuilders.PROJECT_COMMANDS_STATE.create().build(datasource.getName()))
+          .withCallback(SC_OK, new ResponseCodeCallback() {
+            @Override
+            public void onResponseCode(Request request, Response response) {
+              String responseText = response.getText();
+              getView().toggleReadWriteButtons(!"REFRESHING".equals(responseText));
+            }
+          }).get().send();
     }
 
     private void authorize() {
@@ -493,6 +506,8 @@ public class DatasourcePresenter extends PresenterWidget<DatasourcePresenter.Dis
     void afterRenderRows();
 
     void setDatasource(DatasourceDto dto);
+
+    void toggleReadWriteButtons(boolean toggleOn);
 
     HasAuthorization getAddUpdateTablesAuthorizer();
 

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/presenter/TablePresenter.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/presenter/TablePresenter.java
@@ -400,6 +400,7 @@ public class TablePresenter extends PresenterWidget<TablePresenter.Display>
         updateVariables();
         updateTableIndexStatus();
         authorize();
+        initProjectCommandsState();
 
         if (getView().isValuesTabSelected()) {
           valuesTablePresenter.setTable(tableDto);
@@ -440,6 +441,18 @@ public class TablePresenter extends PresenterWidget<TablePresenter.Display>
           .withCallback(new TableIndexStatusUnavailableCallback(), SC_INTERNAL_SERVER_ERROR, SC_FORBIDDEN, SC_NOT_FOUND,
               SC_SERVICE_UNAVAILABLE).withCallback(new TableIndexStatusResourceCallback()).send();
     }
+  }
+
+  private void initProjectCommandsState() {
+    ResourceRequestBuilderFactory.newBuilder()
+        .forResource(UriBuilders.PROJECT_COMMANDS_STATE.create().build(table.getDatasourceName()))
+        .withCallback(SC_OK, new ResponseCodeCallback() {
+          @Override
+          public void onResponseCode(Request request, Response response) {
+            String responseText = response.getText();
+            getView().toggleReadWriteButtons(!"REFRESHING".equals(responseText));
+          }
+        }).get().send();
   }
 
   private void updateVariables() {
@@ -1015,6 +1028,8 @@ public class TablePresenter extends PresenterWidget<TablePresenter.Display>
     void hideContingencyTable();
 
     void setVariableFilter(String variableFilter);
+
+    void toggleReadWriteButtons(boolean toggleOn);
   }
 
   private class RemoveRunnable implements Runnable {

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/view/DatasourceView.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/view/DatasourceView.java
@@ -121,6 +121,12 @@ public class DatasourceView extends ViewWithUiHandlers<DatasourceUiHandlers> imp
   @UiField
   Panel permissionsPanel;
 
+  @UiField
+  IconAnchor exportSelectionAnchor;
+
+  @UiField
+  IconAnchor copySelectionAnchor;
+
   private final ListDataProvider<TableDto> dataProvider = new ListDataProvider<TableDto>();
 
   private final Translations translations;
@@ -313,6 +319,15 @@ public class DatasourceView extends ViewWithUiHandlers<DatasourceUiHandlers> imp
     else addUpdateTables.setText(translations.addUpdateTablesLabel());
 
     checkColumn.clearSelection();
+  }
+
+  @Override
+  public void toggleReadWriteButtons(boolean toggleOn) {
+    importData.setEnabled(toggleOn);
+    exportData.setEnabled(toggleOn);
+    copyData.setEnabled(toggleOn);
+    copySelectionAnchor.setVisible(toggleOn);
+    exportSelectionAnchor.setVisible(toggleOn);
   }
 
   @Override

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/view/TableView.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/view/TableView.java
@@ -227,6 +227,7 @@ public class TableView extends ViewWithUiHandlers<TableUiHandlers> implements Ta
 
   @UiField
   ButtonGroup tableAddVariableGroup;
+
   @UiField
   Tab analysesTab;
 
@@ -489,6 +490,12 @@ public class TableView extends ViewWithUiHandlers<TableUiHandlers> implements Ta
   @Override
   public void setVariableFilter(String variableFilter) {
     filter.setText(variableFilter);
+  }
+
+  @Override
+  public void toggleReadWriteButtons(boolean toggleOn) {
+    copyData.setEnabled(toggleOn);
+    exportData.setEnabled(toggleOn);
   }
 
   @UiHandler("dictionnaryTab")

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/project/admin/ProjectAdministrationPresenter.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/project/admin/ProjectAdministrationPresenter.java
@@ -10,8 +10,27 @@
 
 package org.obiba.opal.web.gwt.app.client.project.admin;
 
+import static com.google.gwt.http.client.Response.SC_CONFLICT;
+import static com.google.gwt.http.client.Response.SC_CREATED;
+import static com.google.gwt.http.client.Response.SC_FORBIDDEN;
+import static com.google.gwt.http.client.Response.SC_INTERNAL_SERVER_ERROR;
+import static com.google.gwt.http.client.Response.SC_NOT_FOUND;
+import static com.google.gwt.http.client.Response.SC_OK;
+
 import com.google.common.collect.Maps;
+import com.google.gwt.http.client.Request;
+import com.google.gwt.http.client.Response;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.web.bindery.event.shared.EventBus;
+import com.gwtplatform.mvp.client.HasUiHandlers;
+import com.gwtplatform.mvp.client.PresenterWidget;
+import com.gwtplatform.mvp.client.View;
+import com.gwtplatform.mvp.client.proxy.PlaceManager;
+import com.gwtplatform.mvp.shared.proxy.PlaceRequest;
+import java.util.Map;
 import org.obiba.opal.web.gwt.app.client.event.ConfirmationEvent;
+import org.obiba.opal.web.gwt.app.client.event.ConfirmationEvent.Handler;
 import org.obiba.opal.web.gwt.app.client.event.ConfirmationRequiredEvent;
 import org.obiba.opal.web.gwt.app.client.event.ConfirmationTerminatedEvent;
 import org.obiba.opal.web.gwt.app.client.event.NotificationEvent;
@@ -26,30 +45,17 @@ import org.obiba.opal.web.gwt.app.client.project.ProjectPlacesHelper;
 import org.obiba.opal.web.gwt.app.client.project.edit.EditProjectModalPresenter;
 import org.obiba.opal.web.gwt.app.client.project.event.ProjectUpdatedEvent;
 import org.obiba.opal.web.gwt.app.client.project.keystore.ProjectKeyStorePresenter;
-import org.obiba.opal.web.gwt.rest.client.*;
+import org.obiba.opal.web.gwt.rest.client.ResourceAuthorizationRequestBuilderFactory;
+import org.obiba.opal.web.gwt.rest.client.ResourceCallback;
+import org.obiba.opal.web.gwt.rest.client.ResourceRequestBuilderFactory;
+import org.obiba.opal.web.gwt.rest.client.ResponseCodeCallback;
+import org.obiba.opal.web.gwt.rest.client.UriBuilder;
+import org.obiba.opal.web.gwt.rest.client.UriBuilders;
 import org.obiba.opal.web.gwt.rest.client.authorization.CompositeAuthorizer;
 import org.obiba.opal.web.gwt.rest.client.authorization.HasAuthorization;
 import org.obiba.opal.web.model.client.opal.PluginPackageDto;
 import org.obiba.opal.web.model.client.opal.PluginPackagesDto;
 import org.obiba.opal.web.model.client.opal.ProjectDto;
-
-import com.google.gwt.http.client.Request;
-import com.google.gwt.http.client.Response;
-import com.google.inject.Inject;
-import com.google.inject.Provider;
-import com.google.web.bindery.event.shared.EventBus;
-import com.gwtplatform.mvp.client.HasUiHandlers;
-import com.gwtplatform.mvp.client.PresenterWidget;
-import com.gwtplatform.mvp.client.View;
-import com.gwtplatform.mvp.client.proxy.PlaceManager;
-import com.gwtplatform.mvp.shared.proxy.PlaceRequest;
-
-import java.util.Map;
-
-import static com.google.gwt.http.client.Response.SC_FORBIDDEN;
-import static com.google.gwt.http.client.Response.SC_INTERNAL_SERVER_ERROR;
-import static com.google.gwt.http.client.Response.SC_NOT_FOUND;
-import static com.google.gwt.http.client.Response.SC_OK;
 
 public class ProjectAdministrationPresenter extends PresenterWidget<ProjectAdministrationPresenter.Display>
     implements ProjectAdministrationUiHandlers {
@@ -67,6 +73,8 @@ public class ProjectAdministrationPresenter extends PresenterWidget<ProjectAdmin
   private ProjectDto project;
 
   private Runnable removeConfirmation;
+
+  private Runnable refreshConfirmation;
 
   private final TranslationMessages translationMessages;
 
@@ -91,6 +99,15 @@ public class ProjectAdministrationPresenter extends PresenterWidget<ProjectAdmin
       @Override
       public void onProjectUpdated(ProjectUpdatedEvent event) {
         placeManager.revealPlace(ProjectPlacesHelper.getAdministrationPlace(project.getName()));
+      }
+    });
+    addRegisteredHandler(ConfirmationEvent.getType(), new Handler() {
+      @Override
+      public void onConfirmation(ConfirmationEvent event) {
+        if (refreshConfirmation != null && event.getSource().equals(refreshConfirmation) && event.isConfirmed()) {
+          refreshConfirmation.run();
+          refreshConfirmation = null;
+        }
       }
     });
   }
@@ -168,6 +185,32 @@ public class ProjectAdministrationPresenter extends PresenterWidget<ProjectAdmin
     removeConfirmation = new RemoveRunnable(project, true);
     fireEvent(ConfirmationRequiredEvent.createWithMessages(removeConfirmation, translationMessages.archiveProject(),
         translationMessages.confirmArchiveProject()));
+  }
+
+  @Override
+  public void onRefresh() {
+    refreshConfirmation = new Runnable() {
+      @Override
+      public void run() {
+        ResourceRequestBuilderFactory.newBuilder() //
+            .forResource(UriBuilders.PROJECT_COMMANDS_REFRESH.create().build(project.getName()))
+            .withCallback(new ResponseCodeCallback() {
+              @Override
+              public void onResponseCode(Request request, Response response) {
+                fireEvent(ConfirmationTerminatedEvent.create());
+                if(response.getStatusCode() != SC_CREATED) {
+                  String errorMessage = response.getText().isEmpty() ? response.getStatusCode() == SC_FORBIDDEN
+                      ? "Forbidden"
+                      : "ProjectMomentarilyNotRefreshable" : response.getText();
+                  fireEvent(NotificationEvent.newBuilder().error(errorMessage).args(project.getName()).build());
+                }
+              }
+            }, SC_CREATED, SC_FORBIDDEN, SC_NOT_FOUND, SC_CONFLICT, SC_INTERNAL_SERVER_ERROR) //
+            .post().send();
+      }
+    };
+
+    fireEvent(ConfirmationRequiredEvent.createWithMessages(refreshConfirmation, translationMessages.refreshProject(), translationMessages.confirmRefreshProject()));
   }
 
   private class RemoveConfirmationEventHandler implements ConfirmationEvent.Handler {

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/project/admin/ProjectAdministrationUiHandlers.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/project/admin/ProjectAdministrationUiHandlers.java
@@ -20,4 +20,6 @@ public interface ProjectAdministrationUiHandlers extends UiHandlers {
 
   void onArchive();
 
+  void onRefresh();
+
 }

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/project/admin/ProjectAdministrationView.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/project/admin/ProjectAdministrationView.java
@@ -10,6 +10,7 @@
 
 package org.obiba.opal.web.gwt.app.client.project.admin;
 
+import com.github.gwtbootstrap.client.ui.Button;
 import com.github.gwtbootstrap.client.ui.Paragraph;
 import com.github.gwtbootstrap.client.ui.base.IconAnchor;
 import com.google.gwt.event.dom.client.ClickEvent;
@@ -191,6 +192,11 @@ public class ProjectAdministrationView extends ViewWithUiHandlers<ProjectAdminis
   @UiHandler("archiveProject")
   void onArchiveProject(ClickEvent event) {
     getUiHandlers().onArchive();
+  }
+
+  @UiHandler("refreshProject")
+  public void onRefreshProject(ClickEvent event) {
+    getUiHandlers().onRefresh();
   }
 
 }

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/project/admin/ProjectAdministrationView.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/project/admin/ProjectAdministrationView.java
@@ -95,6 +95,12 @@ public class ProjectAdministrationView extends ViewWithUiHandlers<ProjectAdminis
   @UiField
   Label exportFolder;
 
+  @UiField
+  Button refreshProject;
+
+  @UiField
+  Label refreshProjectBusy;
+
   private ProjectDto project;
 
   @Inject
@@ -109,6 +115,7 @@ public class ProjectAdministrationView extends ViewWithUiHandlers<ProjectAdminis
     name.setText(project.getName());
     title.setText(project.getTitle());
     description.setText(project.getDescription());
+    refreshProjectBusy.getElement().addClassName("help-block");
     tags.setText("");
     if(project.getTagsArray() != null) tags.setText(project.getTagsArray().join(", "));
     if (project.getExportFolder() != null) exportFolder.setText(project.getExportFolder());
@@ -166,6 +173,12 @@ public class ProjectAdministrationView extends ViewWithUiHandlers<ProjectAdminis
   @Override
   public HasAuthorization getDeleteAuthorizer() {
     return new WidgetAuthorizer(deletePanel);
+  }
+
+  @Override
+  public void toggleRefreshButton(boolean toggleOn) {
+    refreshProject.setEnabled(toggleOn);
+    refreshProjectBusy.setVisible(!toggleOn);
   }
 
   @UiHandler("editProperties")

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/project/admin/ProjectAdministrationView.ui.xml
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/project/admin/ProjectAdministrationView.ui.xml
@@ -137,13 +137,20 @@
       <g:FlowPanel ui:field="permissions"/>
     </g:FlowPanel>
 
+    <g:FlowPanel>
+      <b:Heading size="4">
+        <ui:msg description="Refresh Project label">Refresh Project</ui:msg>
+      </b:Heading>
+      <b:Form>
+        <b:Button type="INFO" ui:field="refreshProject">Refresh</b:Button>
+        <g:Label ui:field="refreshProjectBusy">The project is currently busy, refreshing is unavailable. Try again later.</g:Label>
+      </b:Form>
+    </g:FlowPanel>
+
     <g:FlowPanel ui:field="deletePanel">
       <b:Heading size="4">
         <ui:msg description="Danger Zone label">Danger zone</ui:msg>
       </b:Heading>
-      <b:Form>
-        <b:Button type="INFO" ui:field="refreshProject">Refresh Project</b:Button>
-      </b:Form>
       <b:Paragraph>
         <ui:msg description="Archive Project text">Archiving a project makes its data inaccessible. Project tables,
           views, files, reports and keystore will remain untouched. These data will be reinstated when a project with

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/project/admin/ProjectAdministrationView.ui.xml
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/project/admin/ProjectAdministrationView.ui.xml
@@ -141,6 +141,9 @@
       <b:Heading size="4">
         <ui:msg description="Danger Zone label">Danger zone</ui:msg>
       </b:Heading>
+      <b:Form>
+        <b:Button type="INFO" ui:field="refreshProject">Refresh Project</b:Button>
+      </b:Form>
       <b:Paragraph>
         <ui:msg description="Archive Project text">Archiving a project makes its data inaccessible. Project tables,
           views, files, reports and keystore will remain untouched. These data will be reinstated when a project with

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/rest/client/UriBuilders.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/rest/client/UriBuilders.java
@@ -82,6 +82,13 @@ public enum UriBuilders {
     }
   },
 
+  PROJECT_COMMANDS_REFRESH {
+    @Override
+    public UriBuilder create() {
+      return UriBuilder.create().segment("project", "{}", "commands", "_refresh");
+    }
+  },
+
   PROJECT_PERMISSIONS_SUBJECTS {
     @Override
     public UriBuilder create() {

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/rest/client/UriBuilders.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/rest/client/UriBuilders.java
@@ -89,6 +89,13 @@ public enum UriBuilders {
     }
   },
 
+  PROJECT_COMMANDS_STATE {
+    @Override
+    public UriBuilder create() {
+      return UriBuilder.create().segment("project", "{}", "commands", "state");
+    }
+  },
+
   PROJECT_PERMISSIONS_SUBJECTS {
     @Override
     public UriBuilder create() {

--- a/opal-shell/src/main/java/org/obiba/opal/shell/commands/RefreshCommand.java
+++ b/opal-shell/src/main/java/org/obiba/opal/shell/commands/RefreshCommand.java
@@ -1,0 +1,51 @@
+package org.obiba.opal.shell.commands;
+
+import org.obiba.magma.Datasource;
+import org.obiba.magma.MagmaEngine;
+import org.obiba.magma.views.ViewManager;
+import org.obiba.opal.core.domain.Project;
+import org.obiba.opal.core.service.OrientDbService;
+import org.obiba.opal.core.service.ProjectsServiceImpl;
+import org.obiba.opal.core.service.database.DatabaseRegistry;
+import org.obiba.opal.shell.commands.options.RefreshCommandOptions;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallbackWithoutResult;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@CommandUsage(description = "Refresh a project's underlying datasource.", syntax = "Syntax: refresh --project PROJECT")
+public class RefreshCommand extends AbstractOpalRuntimeDependentCommand<RefreshCommandOptions> {
+
+  @Autowired
+  private TransactionTemplate transactionTemplate;
+
+  @Autowired
+  private ViewManager viewManager;
+
+  @Autowired
+  private OrientDbService orientDbService;
+
+  @Autowired
+  private DatabaseRegistry databaseRegistry;
+
+  @Override
+  public int execute() {
+    String projectName = getOptions().getProject();
+    Project project = orientDbService.findUnique(new Project(projectName));
+
+    if (project != null && MagmaEngine.get().hasDatasource(project.getName())) {
+      transactionTemplate.execute(new TransactionCallbackWithoutResult() {
+        @Override
+        protected void doInTransactionWithoutResult(TransactionStatus status) {
+          Datasource datasource = MagmaEngine.get().getDatasource(project.getName());
+          MagmaEngine.get().removeDatasource(datasource);
+          viewManager.unregisterDatasource(datasource.getName());
+
+          ProjectsServiceImpl.registerDatasource(project, transactionTemplate, databaseRegistry);
+        }
+      });
+    }
+
+    return 0;
+  }
+}

--- a/opal-shell/src/main/java/org/obiba/opal/shell/commands/options/RefreshCommandOptions.java
+++ b/opal-shell/src/main/java/org/obiba/opal/shell/commands/options/RefreshCommandOptions.java
@@ -1,0 +1,11 @@
+package org.obiba.opal.shell.commands.options;
+
+import uk.co.flamingpenguin.jewel.cli.CommandLineInterface;
+import uk.co.flamingpenguin.jewel.cli.Option;
+
+@CommandLineInterface(application = "refresh")
+public interface RefreshCommandOptions extends HelpOption {
+
+  @Option(longName = "project", shortName = "p", description = "The project for which the underlying datasource will be refreshed.")
+  String getProject();
+}

--- a/opal-shell/src/main/java/org/obiba/opal/shell/web/RefreshCommandOptionsDtoImpl.java
+++ b/opal-shell/src/main/java/org/obiba/opal/shell/web/RefreshCommandOptionsDtoImpl.java
@@ -1,0 +1,23 @@
+package org.obiba.opal.shell.web;
+
+import org.obiba.opal.shell.commands.options.RefreshCommandOptions;
+import org.obiba.opal.web.model.Commands.RefreshCommandOptionsDto;
+
+public class RefreshCommandOptionsDtoImpl implements RefreshCommandOptions {
+
+  private final RefreshCommandOptionsDto dto;
+
+  public RefreshCommandOptionsDtoImpl(RefreshCommandOptionsDto dto) {
+    this.dto = dto;
+  }
+
+  @Override
+  public String getProject() {
+    return dto.getProject();
+  }
+
+  @Override
+  public boolean isHelp() {
+    return false;
+  }
+}

--- a/opal-shell/src/main/java/org/obiba/opal/shell/web/WebShellCommandRegistry.java
+++ b/opal-shell/src/main/java/org/obiba/opal/shell/web/WebShellCommandRegistry.java
@@ -28,6 +28,7 @@ public class WebShellCommandRegistry extends AbstractCommandRegistry {
     addAvailableCommand(CopyCommand.class, CopyCommandOptions.class);
     addAvailableCommand("export", CopyCommand.class, CopyCommandOptions.class);
     addAvailableCommand("analyse", AnalyseCommand.class, AnalyseCommandOptions.class);
+    addAvailableCommand("refresh", RefreshCommand.class, RefreshCommandOptions.class);
     addAvailableCommand(ReportCommand.class, ReportCommandOptions.class);
     addAvailableCommand(ImportVCFCommand.class, ImportVCFCommandOptions.class);
     addAvailableCommand(ExportVCFCommand.class, ExportVCFCommandOptions.class);

--- a/opal-web-model/src/main/protobuf/Commands.proto
+++ b/opal-web-model/src/main/protobuf/Commands.proto
@@ -111,3 +111,7 @@ message AnalyseCommandOptionsDto {
   required string project = 1;
   repeated AnalyseDto analyses = 2;
 }
+
+message RefreshCommandOptionsDto {
+  required string project = 1;
+}


### PR DESCRIPTION
related to obiba/opal#3453 

* added `/project/{name}/commands/_refresh` rest resource
* added `/project/{name}/commands/state` rest resource
* UI: query state on datasource/table selection and enable/disable import/export/copy buttons depending on returned state
* UI: query state on project administration page load and enable/disable refresh button depending on returned state
* server: check 'state' for import/export/copy/refresh commands and throw exception depending on states

available states: BUSY, READY, REFRESHING
where BUSY blocks refresh commands and REFRESHING blocks import/export/copy/refresh. READY is the idle state.