### PR TITLE
Improvement/refresh project

### DIFF
--- a/opal-core-api/src/main/java/org/obiba/opal/core/domain/ProjectsState.java
+++ b/opal-core-api/src/main/java/org/obiba/opal/core/domain/ProjectsState.java
@@ -1,0 +1,37 @@
+package org.obiba.opal.core.domain;
+
+import com.google.common.base.Strings;
+import java.util.HashMap;
+import java.util.Map;
+import javax.validation.constraints.NotNull;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+@Component
+@Scope(ConfigurableBeanFactory.SCOPE_SINGLETON)
+public class ProjectsState {
+
+  private final Map<String, State> projectsStateRegistry;
+
+  public ProjectsState() {
+    projectsStateRegistry = new HashMap<>();
+  }
+
+  public synchronized String getProjectState(@NotNull String name) {
+    return projectsStateRegistry.getOrDefault(name, State.READY).name();
+  }
+
+  public synchronized void updateProjectState(@NotNull String name, State state) {
+    if (!Strings.isNullOrEmpty(name)) {
+      projectsStateRegistry.put(name, state != null ? state : State.READY);
+    }
+  }
+
+  public enum State {
+    BUSY, // project has read, write and refresh commands that are pending or being processed
+    READY,
+    REFRESHING // project's datasource is not ready
+  }
+
+}

--- a/opal-core-ws/src/main/java/org/obiba/opal/core/security/DatasourcePermissionConverter.java
+++ b/opal-core-ws/src/main/java/org/obiba/opal/core/security/DatasourcePermissionConverter.java
@@ -68,6 +68,7 @@ public class DatasourcePermissionConverter extends OpalPermissionConverter {
             toRest("/identifiers/mappings", "GET"), //
             toRest("/datasource-plugin", "GET:GET/GET"), //
             toRest("/project/{0}", "GET:GET", args),//
+            toRest("/project/{0}/state", "GET:GET", args),//
             toRest("/project/{0}/summary", "GET:GET", args),//
             toRest("/project/{0}/transient-datasources", "POST", args),//
             toRest("/project/{0}/commands/_import", "POST:GET", args),//
@@ -91,6 +92,7 @@ public class DatasourcePermissionConverter extends OpalPermissionConverter {
             toRest("/project/{0}/report-templates", "GET:GET", args),//
             toRest("/project/{0}/report-templates", "POST:GET", args),//
             toRest("/project/{0}", "GET:GET", args),//
+            toRest("/project/{0}/state", "GET:GET", args),//
             toRest("/project/{0}/summary", "GET:GET", args),
             toRest("/project/{0}/analyses", "GET:GET", args),
             toRest("/project/{0}/analyses/_export", "GET:GET", args));

--- a/opal-core-ws/src/main/java/org/obiba/opal/core/security/TablePermissionConverter.java
+++ b/opal-core-ws/src/main/java/org/obiba/opal/core/security/TablePermissionConverter.java
@@ -52,6 +52,7 @@ public class TablePermissionConverter extends OpalPermissionConverter {
             toRest("/project/{0}/report-templates", "GET:GET", args),//
             toRest("/project/{0}/report-templates", "POST:GET", args),//
             toRest("/project/{0}", "GET:GET", args),//
+            toRest("/project/{0}/state", "GET:GET", args),//
             toRest("/project/{0}/summary", "GET:GET", args),//
             toRest("/project/{0}/permissions/table/{1}", "*:GET/*", args),//
             toRest("/files/projects/{0}", "GET:GET/*", args), //
@@ -79,6 +80,7 @@ public class TablePermissionConverter extends OpalPermissionConverter {
             toRest("/datasource/{0}/table/{1}/facets/_search", "POST:GET", args),//
             toRest("/datasource/{0}/table/{1}/variable/_transient/summary", "POST", args),//
             toRest("/project/{0}", "GET:GET", args),//
+            toRest("/project/{0}/state", "GET:GET", args),//
             toRest("/project/{0}/summary", "GET:GET", args));
 
         if(isView) perms.add(toRest("/datasource/{0}/view/{1}/xml", "GET:GET", args));
@@ -106,6 +108,7 @@ public class TablePermissionConverter extends OpalPermissionConverter {
             toRest("/project/{0}/report-templates", "GET:GET", args),//
             toRest("/project/{0}/report-templates", "POST:GET", args),//
             toRest("/project/{0}", "GET:GET", args),//
+            toRest("/project/{0}/state", "GET:GET", args),//
             toRest("/project/{0}/summary", "GET:GET", args),
             toRest("/project/{0}/analyses", "GET:GET", args),
             toRest("/project/{0}/table/{1}/analyses", "GET:GET", args),

--- a/opal-core-ws/src/main/java/org/obiba/opal/core/security/VariablePermissionConverter.java
+++ b/opal-core-ws/src/main/java/org/obiba/opal/core/security/VariablePermissionConverter.java
@@ -43,6 +43,7 @@ public class VariablePermissionConverter extends OpalPermissionConverter {
         return Lists.newArrayList(toRest("/datasource/{0}/table/{1}/variable/{2}", "GET:GET/GET", args),//
             toRest("/datasource/{0}/table/{1}/variable/_transient/summary", "POST:GET", args),//
             toRest("/project/{0}", "GET:GET", args),//
+            toRest("/project/{0}/state", "GET:GET", args),//
             toRest("/project/{0}/summary", "GET:GET", args));
       }
     };

--- a/opal-core-ws/src/main/java/org/obiba/opal/web/project/ProjectResource.java
+++ b/opal-core-ws/src/main/java/org/obiba/opal/web/project/ProjectResource.java
@@ -10,6 +10,7 @@
 package org.obiba.opal.web.project;
 
 import com.google.common.eventbus.EventBus;
+import javax.ws.rs.core.Response.ResponseBuilder;
 import org.apache.commons.vfs2.FileSystemException;
 import org.obiba.magma.Datasource;
 import org.obiba.magma.Timestamped;
@@ -158,5 +159,33 @@ public class ProjectResource {
     public Timestamps getTimestamps() {
       return timestamps;
     }
+  }
+
+  @GET
+  @Path("/state")
+  public Response getState(@PathParam("name") String name) {
+    Project project = projectService.getProject(name);
+
+    boolean isRefreshing = !project.hasDatasource();
+    boolean isBusy = isRefreshing;
+
+    ResponseBuilder responseBuilder = Response.ok();
+
+    if (isBusy) {
+      responseBuilder.entity(State.BUSY.name());
+    } else if (isRefreshing) {
+      responseBuilder.entity(State.REFRESHING.name());
+    } else {
+      responseBuilder.entity(State.READY.name());
+    }
+
+    return responseBuilder.build();
+  }
+
+
+  public enum State {
+    BUSY, // project has read, write and refresh commands that are pending or being processed
+    READY,
+    REFRESHING // project's datasource is not ready
   }
 }

--- a/opal-core-ws/src/test/java/org/obiba/opal/core/security/DatasourcePermissionConverterTest.java
+++ b/opal-core-ws/src/test/java/org/obiba/opal/core/security/DatasourcePermissionConverterTest.java
@@ -47,6 +47,7 @@ public class DatasourcePermissionConverterTest
         "rest:/project/patate/report-templates:GET:GET", //
         "rest:/project/patate/report-templates:POST:GET", //
         "rest:/project/patate:GET:GET", //
+        "rest:/project/patate/state:GET:GET",
         "rest:/project/patate/summary:GET:GET",
         "rest:/project/patate/analyses:GET:GET",
         "rest:/project/patate/analyses/_export:GET:GET");
@@ -62,6 +63,7 @@ public class DatasourcePermissionConverterTest
         "rest:/identifiers/mappings:GET", //
         "rest:/datasource-plugin:GET:GET/GET", //
         "rest:/project/patate:GET:GET", //
+        "rest:/project/patate/state:GET:GET",
         "rest:/project/patate/summary:GET:GET", //
         "rest:/project/patate/transient-datasources:POST", //
         "rest:/project/patate/commands/_import:POST:GET", //

--- a/opal-core-ws/src/test/java/org/obiba/opal/core/security/TablePermissionConverterTest.java
+++ b/opal-core-ws/src/test/java/org/obiba/opal/core/security/TablePermissionConverterTest.java
@@ -37,6 +37,7 @@ public class TablePermissionConverterTest extends OpalPermissionConverterTest<Ta
         "rest:/project/patate/report-templates:GET:GET", //
         "rest:/project/patate/report-templates:POST:GET", //
         "rest:/project/patate:GET:GET", //
+        "rest:/project/patate/state:GET:GET", //
         "rest:/project/patate/summary:GET:GET", //
         "rest:/project/patate/permissions/table/pwel:*:GET/*", //
         "rest:/files/projects/patate:GET:GET/*", //
@@ -54,6 +55,7 @@ public class TablePermissionConverterTest extends OpalPermissionConverterTest<Ta
         "rest:/project/patate/report-templates:GET:GET", //
         "rest:/project/patate/report-templates:POST:GET", //
         "rest:/project/patate:GET:GET", //
+        "rest:/project/patate/state:GET:GET", //
         "rest:/project/patate/summary:GET:GET", //
         "rest:/project/patate/permissions/table/pwel:*:GET/*", //
         "rest:/files/projects/patate:GET:GET/*", //
@@ -82,6 +84,7 @@ public class TablePermissionConverterTest extends OpalPermissionConverterTest<Ta
         "rest:/datasource/patate/table/pwel/facets/_search:POST:GET",//
         "rest:/datasource/patate/table/pwel/variable/_transient/summary:POST", //
         "rest:/project/patate:GET:GET", //
+        "rest:/project/patate/state:GET:GET", //
         "rest:/project/patate/summary:GET:GET");
   }
 
@@ -101,6 +104,7 @@ public class TablePermissionConverterTest extends OpalPermissionConverterTest<Ta
         "rest:/project/patate/report-templates:GET:GET", //
         "rest:/project/patate/report-templates:POST:GET", //
         "rest:/project/patate:GET:GET", //
+        "rest:/project/patate/state:GET:GET", //
         "rest:/project/patate/summary:GET:GET", //
         "rest:/project/patate/analyses:GET:GET", //
         "rest:/project/patate/table/pwel/analyses:GET:GET",
@@ -115,6 +119,7 @@ public class TablePermissionConverterTest extends OpalPermissionConverterTest<Ta
         "rest:/datasource/patate/table/pwel/facets/_search:POST:GET", //
         "rest:/datasource/patate/table/pwel/variable/_transient/summary:POST", //
         "rest:/project/patate:GET:GET", //
+        "rest:/project/patate/state:GET:GET", //
         "rest:/project/patate/summary:GET:GET", //
         "rest:/datasource/patate/table/pwel:PUT:GET", //
         "rest:/datasource/patate/table/pwel/variables:POST:GET/*", //
@@ -133,6 +138,7 @@ public class TablePermissionConverterTest extends OpalPermissionConverterTest<Ta
         "rest:/datasource/patate/table/pwel/facets/_search:POST:GET", //
         "rest:/datasource/patate/table/pwel/variable/_transient/summary:POST", //
         "rest:/project/patate:GET:GET", //
+        "rest:/project/patate/state:GET:GET", //
         "rest:/project/patate/summary:GET:GET");
   }
 
@@ -148,6 +154,7 @@ public class TablePermissionConverterTest extends OpalPermissionConverterTest<Ta
         "rest:/datasource/patate/table/pwel/facets/_search:POST:GET",//
         "rest:/datasource/patate/table/pwel/variable/_transient/summary:POST",//
         "rest:/project/patate:GET:GET", //
+        "rest:/project/patate/state:GET:GET", //
         "rest:/project/patate/summary:GET:GET", //
         "rest:/datasource/patate/view/pwel/xml:GET:GET");
   }
@@ -168,6 +175,7 @@ public class TablePermissionConverterTest extends OpalPermissionConverterTest<Ta
         "rest:/project/patate/report-templates:GET:GET", //
         "rest:/project/patate/report-templates:POST:GET", //
         "rest:/project/patate:GET:GET", //
+        "rest:/project/patate/state:GET:GET", //
         "rest:/project/patate/summary:GET:GET", //
         "rest:/project/patate/analyses:GET:GET",
         "rest:/project/patate/table/pwel/analyses:GET:GET",
@@ -182,6 +190,7 @@ public class TablePermissionConverterTest extends OpalPermissionConverterTest<Ta
         "rest:/datasource/patate/table/pwel/facets/_search:POST:GET", //
         "rest:/datasource/patate/table/pwel/variable/_transient/summary:POST", //
         "rest:/project/patate:GET:GET", //
+        "rest:/project/patate/state:GET:GET", //
         "rest:/project/patate/summary:GET:GET", //
         "rest:/datasource/patate/view/pwel/xml:GET:GET");
   }

--- a/opal-core-ws/src/test/java/org/obiba/opal/core/security/VariablePermissionConverterTest.java
+++ b/opal-core-ws/src/test/java/org/obiba/opal/core/security/VariablePermissionConverterTest.java
@@ -24,6 +24,7 @@ public class VariablePermissionConverterTest
         "rest:/datasource/patate/table/pwel/variable/pouet:GET:GET/GET", //
         "rest:/datasource/patate/table/pwel/variable/_transient/summary:POST:GET", //
         "rest:/project/patate:GET:GET", //
+        "rest:/project/patate/state:GET:GET",
         "rest:/project/patate/summary:GET:GET");
   }
 

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/i18n/Translations.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/i18n/Translations.java
@@ -2177,6 +2177,10 @@ public interface Translations extends Constants {
   @DefaultStringValue("Server has been running for {0}.")
   String serverRunningFor();
 
+  @Description("")
+  @DefaultStringValue("The project's datasource is refreshing, Read and Write actions are temporarily unavailable. Try again later.")
+  String projectRefreshingText();
+
   @Description("JVM Labels")
   @DefaultStringMapValue({ "OPAL_VERSION", "Opal Version",//
       "JAVA_VERSION", "Java Version", //

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/presenter/DatasourcePresenter.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/presenter/DatasourcePresenter.java
@@ -329,7 +329,7 @@ public class DatasourcePresenter extends PresenterWidget<DatasourcePresenter.Dis
 
     private void initProjectCommandsState() {
       ResourceRequestBuilderFactory.newBuilder()
-          .forResource(UriBuilders.PROJECT_COMMANDS_STATE.create().build(datasource.getName()))
+          .forResource(UriBuilders.PROJECT_STATE.create().build(datasource.getName()))
           .withCallback(SC_OK, new ResponseCodeCallback() {
             @Override
             public void onResponseCode(Request request, Response response) {

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/presenter/DatasourcePresenter.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/presenter/DatasourcePresenter.java
@@ -297,7 +297,6 @@ public class DatasourcePresenter extends PresenterWidget<DatasourcePresenter.Dis
     private void displayDatasource(DatasourceDto datasourceDto) {
       getView().setDatasource(datasourceDto);
       updateTables();
-      initProjectCommandsState();
       authorize();
     }
 
@@ -325,18 +324,6 @@ public class DatasourcePresenter extends PresenterWidget<DatasourcePresenter.Dis
               getView().afterRenderRows();
             }
           }, Response.SC_BAD_REQUEST, Response.SC_INTERNAL_SERVER_ERROR, Response.SC_NOT_FOUND, Response.SC_FORBIDDEN).send();
-    }
-
-    private void initProjectCommandsState() {
-      ResourceRequestBuilderFactory.newBuilder()
-          .forResource(UriBuilders.PROJECT_STATE.create().build(datasource.getName()))
-          .withCallback(SC_OK, new ResponseCodeCallback() {
-            @Override
-            public void onResponseCode(Request request, Response response) {
-              String responseText = response.getText();
-              getView().toggleReadWriteButtons(!"REFRESHING".equals(responseText));
-            }
-          }).get().send();
     }
 
     private void authorize() {
@@ -506,8 +493,6 @@ public class DatasourcePresenter extends PresenterWidget<DatasourcePresenter.Dis
     void afterRenderRows();
 
     void setDatasource(DatasourceDto dto);
-
-    void toggleReadWriteButtons(boolean toggleOn);
 
     HasAuthorization getAddUpdateTablesAuthorizer();
 

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/presenter/MagmaPresenter.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/presenter/MagmaPresenter.java
@@ -107,7 +107,21 @@ public class MagmaPresenter extends PresenterWidget<MagmaPresenter.Display>
   public void onMagmaPathSelection(MagmaPathSelectionEvent event) {
     if(event.getSource() == this) return;
 
-    MagmaPath.Parser parser = event.getParser();
+    final MagmaPath.Parser parser = event.getParser();
+    ResourceRequestBuilderFactory.newBuilder().forResource(UriBuilders.PROJECT_STATE.create().build(parser.getDatasource()))
+      .withCallback(Response.SC_OK, new ResponseCodeCallback() {
+        @Override
+        public void onResponseCode(Request request, Response response) {
+          if (!"REFRESHING".equals(response.getText())) {
+            doShow(parser);
+          } else {
+            getView().showRefreshingMessage(parser.getDatasource());
+          }
+        }
+      }).get().send();
+  }
+
+  private void doShow(MagmaPath.Parser parser) {
     if(parser.hasVariable()) {
       show(parser.getDatasource(), parser.getTable(), parser.getVariable());
     } else if(parser.hasTable()) {
@@ -165,6 +179,8 @@ public class MagmaPresenter extends PresenterWidget<MagmaPresenter.Display>
     void selectTable(String datasource, String table, boolean isView);
 
     void selectVariable(String datasource, String table, String variable);
+
+    void showRefreshingMessage(String datasource);
   }
 
   private class TableDtoResourceCallback implements ResourceCallback<TableDto> {

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/presenter/TablePresenter.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/presenter/TablePresenter.java
@@ -399,7 +399,6 @@ public class TablePresenter extends PresenterWidget<TablePresenter.Display>
         updateVariables();
         updateTableIndexStatus();
         authorize();
-        initProjectCommandsState();
 
         if (getView().isValuesTabSelected()) {
           valuesTablePresenter.setTable(tableDto);
@@ -440,18 +439,6 @@ public class TablePresenter extends PresenterWidget<TablePresenter.Display>
           .withCallback(new TableIndexStatusUnavailableCallback(), SC_INTERNAL_SERVER_ERROR, SC_FORBIDDEN, SC_NOT_FOUND,
               SC_SERVICE_UNAVAILABLE).withCallback(new TableIndexStatusResourceCallback()).send();
     }
-  }
-
-  private void initProjectCommandsState() {
-    ResourceRequestBuilderFactory.newBuilder()
-        .forResource(UriBuilders.PROJECT_STATE.create().build(table.getDatasourceName()))
-        .withCallback(SC_OK, new ResponseCodeCallback() {
-          @Override
-          public void onResponseCode(Request request, Response response) {
-            String responseText = response.getText();
-            getView().toggleReadWriteButtons(!"REFRESHING".equals(responseText));
-          }
-        }).get().send();
   }
 
   private void updateVariables() {
@@ -1027,8 +1014,6 @@ public class TablePresenter extends PresenterWidget<TablePresenter.Display>
     void hideContingencyTable();
 
     void setVariableFilter(String variableFilter);
-
-    void toggleReadWriteButtons(boolean toggleOn);
   }
 
   private class RemoveRunnable implements Runnable {

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/presenter/TablePresenter.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/presenter/TablePresenter.java
@@ -14,7 +14,6 @@ import com.google.common.collect.Maps;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.core.client.JsonUtils;
-import com.google.gwt.core.shared.GWT;
 import com.google.gwt.http.client.Request;
 import com.google.gwt.http.client.Response;
 import com.google.gwt.user.cellview.client.ColumnSortEvent;
@@ -421,7 +420,7 @@ public class TablePresenter extends PresenterWidget<TablePresenter.Display>
             getView().setFromTables(null, null);
             getView().setWhereScript(null);
           }
-        }, SC_FORBIDDEN, SC_INTERNAL_SERVER_ERROR, SC_NOT_FOUND)//
+        }, SC_FORBIDDEN, SC_INTERNAL_SERVER_ERROR, SC_NOT_FOUND)
         .withCallback(new ViewResourceCallback()).send();
   }
 
@@ -445,7 +444,7 @@ public class TablePresenter extends PresenterWidget<TablePresenter.Display>
 
   private void initProjectCommandsState() {
     ResourceRequestBuilderFactory.newBuilder()
-        .forResource(UriBuilders.PROJECT_COMMANDS_STATE.create().build(table.getDatasourceName()))
+        .forResource(UriBuilders.PROJECT_STATE.create().build(table.getDatasourceName()))
         .withCallback(SC_OK, new ResponseCodeCallback() {
           @Override
           public void onResponseCode(Request request, Response response) {

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/view/DatasourceView.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/view/DatasourceView.java
@@ -322,15 +322,6 @@ public class DatasourceView extends ViewWithUiHandlers<DatasourceUiHandlers> imp
   }
 
   @Override
-  public void toggleReadWriteButtons(boolean toggleOn) {
-    importData.setEnabled(toggleOn);
-    exportData.setEnabled(toggleOn);
-    copyData.setEnabled(toggleOn);
-    copySelectionAnchor.setVisible(toggleOn);
-    exportSelectionAnchor.setVisible(toggleOn);
-  }
-
-  @Override
   public HasAuthorization getAddUpdateTablesAuthorizer() {
     return new CompositeAuthorizer(new WidgetAuthorizer(addTable), new WidgetAuthorizer(addUpdateTables)) {
       @Override

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/view/MagmaView.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/view/MagmaView.java
@@ -10,6 +10,7 @@
 
 package org.obiba.opal.web.gwt.app.client.magma.view;
 
+import com.google.gwt.user.client.ui.FlowPanel;
 import org.obiba.opal.web.gwt.app.client.i18n.Translations;
 import org.obiba.opal.web.gwt.app.client.magma.presenter.MagmaPresenter;
 import org.obiba.opal.web.gwt.app.client.project.ProjectPlacesHelper;
@@ -18,7 +19,6 @@ import org.obiba.opal.web.gwt.app.client.ui.BreadcrumbsTabPanel;
 import com.github.gwtbootstrap.client.ui.Badge;
 import com.github.gwtbootstrap.client.ui.Heading;
 import com.github.gwtbootstrap.client.ui.NavLink;
-import com.github.gwtbootstrap.client.ui.NavPills;
 import com.github.gwtbootstrap.client.ui.constants.BadgeType;
 import com.google.gwt.event.dom.client.HasClickHandlers;
 import com.google.gwt.event.logical.shared.SelectionEvent;
@@ -131,6 +131,23 @@ public class MagmaView extends ViewImpl implements MagmaPresenter.Display {
     badge.setType(BadgeType.IMPORTANT);
     badge.setText("V");
     badge.setTitle(translations.variableLabel());
+    setHeading();
+  }
+
+  @Override
+  public void showRefreshingMessage(String datasource) {
+    tabPanel.clear();
+
+    FlowPanel flowPanel = new FlowPanel();
+    flowPanel.getElement().setInnerText(translations.projectRefreshingText());
+    tabPanel.add(flowPanel, getDatasourceLink(datasource));
+
+    tabPanel.setMenuVisible(true);
+
+    badge.setType(BadgeType.INFO);
+    badge.setText("D");
+    badge.setTitle(translations.datasourceLabel());
+
     setHeading();
   }
 

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/view/TableView.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/magma/view/TableView.java
@@ -492,12 +492,6 @@ public class TableView extends ViewWithUiHandlers<TableUiHandlers> implements Ta
     filter.setText(variableFilter);
   }
 
-  @Override
-  public void toggleReadWriteButtons(boolean toggleOn) {
-    copyData.setEnabled(toggleOn);
-    exportData.setEnabled(toggleOn);
-  }
-
   @UiHandler("dictionnaryTab")
   void onDictionnaryTabSelect(ClickEvent event) {
     getUiHandlers().onShowDictionary();

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/project/admin/ProjectAdministrationPresenter.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/project/admin/ProjectAdministrationPresenter.java
@@ -140,7 +140,7 @@ public class ProjectAdministrationPresenter extends PresenterWidget<ProjectAdmin
 
   private void initProjectState() {
     ResourceRequestBuilderFactory.newBuilder()
-        .forResource(UriBuilders.PROJECT_COMMANDS_STATE.create().build(project.getName()))
+        .forResource(UriBuilders.PROJECT_STATE.create().build(project.getName()))
         .withCallback(SC_OK, new ResponseCodeCallback() {
           @Override
           public void onResponseCode(Request request, Response response) {

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/project/admin/ProjectAdministrationPresenter.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/project/admin/ProjectAdministrationPresenter.java
@@ -104,7 +104,7 @@ public class ProjectAdministrationPresenter extends PresenterWidget<ProjectAdmin
     addRegisteredHandler(ConfirmationEvent.getType(), new Handler() {
       @Override
       public void onConfirmation(ConfirmationEvent event) {
-        if (refreshConfirmation != null && event.getSource().equals(refreshConfirmation) && event.isConfirmed()) {
+        if (event.getSource().equals(refreshConfirmation) && event.isConfirmed()) {
           refreshConfirmation.run();
           refreshConfirmation = null;
         }
@@ -145,7 +145,7 @@ public class ProjectAdministrationPresenter extends PresenterWidget<ProjectAdmin
           @Override
           public void onResponseCode(Request request, Response response) {
             String responseText = response.getText();
-            getView().toggleRefreshButton(!"BUSY".equals(responseText));
+            getView().toggleRefreshButton("READY".equals(responseText));
           }
         }).get().send();
   }

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/project/admin/ProjectAdministrationView.ui.xml
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/app/client/project/admin/ProjectAdministrationView.ui.xml
@@ -145,6 +145,12 @@
         <b:Button type="INFO" ui:field="refreshProject">Refresh</b:Button>
         <g:Label ui:field="refreshProjectBusy">The project is currently busy, refreshing is unavailable. Try again later.</g:Label>
       </b:Form>
+      <b:Paragraph>
+        <ui:msg description="Refresh Project text">Refreshing a project makes its data temporarily inaccessible (no table listing, no import or export)
+          while the connection to the database is being re-initialised.
+          The time taken by this operation depends on the database type and schema.
+        </ui:msg>
+      </b:Paragraph>
     </g:FlowPanel>
 
     <g:FlowPanel ui:field="deletePanel">

--- a/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/rest/client/UriBuilders.java
+++ b/opal-gwt-client/src/main/java/org/obiba/opal/web/gwt/rest/client/UriBuilders.java
@@ -89,10 +89,10 @@ public enum UriBuilders {
     }
   },
 
-  PROJECT_COMMANDS_STATE {
+  PROJECT_STATE {
     @Override
     public UriBuilder create() {
-      return UriBuilder.create().segment("project", "{}", "commands", "state");
+      return UriBuilder.create().segment("project", "{}", "state");
     }
   },
 

--- a/opal-shell/src/main/java/org/obiba/opal/shell/commands/CopyCommand.java
+++ b/opal-shell/src/main/java/org/obiba/opal/shell/commands/CopyCommand.java
@@ -31,6 +31,8 @@ import org.obiba.magma.js.support.JavascriptVariableTransformer;
 import org.obiba.magma.support.*;
 import org.obiba.magma.views.View;
 import org.obiba.magma.views.support.AllClause;
+import org.obiba.opal.core.domain.ProjectsState;
+import org.obiba.opal.core.domain.ProjectsState.State;
 import org.obiba.opal.core.domain.database.Database;
 import org.obiba.opal.core.domain.security.SubjectAcl;
 import org.obiba.opal.core.event.ValueTableAddedEvent;
@@ -146,11 +148,15 @@ public class CopyCommand extends AbstractOpalRuntimeDependentCommand<CopyCommand
 
     Stopwatch stopwatch = Stopwatch.createStarted();
 
+    final ProjectsState projectsState = applicationContext.getBean(ProjectsState.class);
+    projectsState.updateProjectState(options.getDestination(), State.BUSY);
+
     if(validateOptions()) {
       Datasource destinationDatasource = null;
 
       try {
         destinationDatasource = getDestinationDatasource();
+
         Set<ValueTable> tables = getValueTables();
         for(ValueTable table : tables) {
           if(destinationDatasource.getName().equals(table.getDatasource().getName()) &&
@@ -187,6 +193,7 @@ public class CopyCommand extends AbstractOpalRuntimeDependentCommand<CopyCommand
       log.info("Copy succeed in {}", stopwatch.stop());
     }
 
+    projectsState.updateProjectState(options.getDestination(), State.READY);
     return errorCode;
   }
 

--- a/opal-shell/src/main/java/org/obiba/opal/shell/commands/ImportCommand.java
+++ b/opal-shell/src/main/java/org/obiba/opal/shell/commands/ImportCommand.java
@@ -21,6 +21,8 @@ import org.obiba.crypt.KeyProviderException;
 import org.obiba.magma.DatasourceCopierProgressListener;
 import org.obiba.magma.NoSuchDatasourceException;
 import org.obiba.magma.NoSuchValueTableException;
+import org.obiba.opal.core.domain.ProjectsState;
+import org.obiba.opal.core.domain.ProjectsState.State;
 import org.obiba.opal.core.domain.security.SubjectAcl;
 import org.obiba.opal.core.event.ValueTableAddedEvent;
 import org.obiba.opal.core.service.DataImportService;
@@ -61,11 +63,16 @@ public class ImportCommand extends AbstractOpalRuntimeDependentCommand<ImportCom
   @Autowired
   private EventBus eventBus;
 
+  @Autowired
+  private ProjectsState projectsState;
+
   @Override
   public int execute() {
     int errorCode;
 
     Stopwatch stopwatch = Stopwatch.createStarted();
+
+    projectsState.updateProjectState(options.getDestination(), State.BUSY);
 
     List<FileObject> filesToImport = getFilesToImport();
     errorCode = executeImports(filesToImport);
@@ -81,6 +88,8 @@ public class ImportCommand extends AbstractOpalRuntimeDependentCommand<ImportCom
       getShell().printf("Import done.\n");
       log.info("Import succeed in {}", stopwatch.stop());
     }
+
+    projectsState.updateProjectState(options.getDestination(), State.READY);
     return errorCode;
   }
 

--- a/opal-shell/src/main/java/org/obiba/opal/shell/commands/RefreshCommand.java
+++ b/opal-shell/src/main/java/org/obiba/opal/shell/commands/RefreshCommand.java
@@ -4,6 +4,8 @@ import org.obiba.magma.Datasource;
 import org.obiba.magma.MagmaEngine;
 import org.obiba.magma.views.ViewManager;
 import org.obiba.opal.core.domain.Project;
+import org.obiba.opal.core.domain.ProjectsState;
+import org.obiba.opal.core.domain.ProjectsState.State;
 import org.obiba.opal.core.service.OrientDbService;
 import org.obiba.opal.core.service.ProjectsServiceImpl;
 import org.obiba.opal.core.service.database.DatabaseRegistry;
@@ -28,12 +30,17 @@ public class RefreshCommand extends AbstractOpalRuntimeDependentCommand<RefreshC
   @Autowired
   private DatabaseRegistry databaseRegistry;
 
+  @Autowired
+  private ProjectsState projectsState;
+
   @Override
   public int execute() {
     String projectName = getOptions().getProject();
     Project project = orientDbService.findUnique(new Project(projectName));
 
     if (project != null && MagmaEngine.get().hasDatasource(project.getName())) {
+      projectsState.updateProjectState(projectName, State.REFRESHING);
+
       transactionTemplate.execute(new TransactionCallbackWithoutResult() {
         @Override
         protected void doInTransactionWithoutResult(TransactionStatus status) {
@@ -46,6 +53,7 @@ public class RefreshCommand extends AbstractOpalRuntimeDependentCommand<RefreshC
       });
     }
 
+    projectsState.updateProjectState(projectName, State.READY);
     return 0;
   }
 }

--- a/opal-shell/src/main/java/org/obiba/opal/web/shell/ProjectCommandsResource.java
+++ b/opal-shell/src/main/java/org/obiba/opal/web/shell/ProjectCommandsResource.java
@@ -10,7 +10,6 @@
 package org.obiba.opal.web.shell;
 
 import com.google.common.collect.Lists;
-import java.util.Arrays;
 import org.apache.shiro.SecurityUtils;
 import org.obiba.magma.Datasource;
 import org.obiba.magma.MagmaEngine;
@@ -19,15 +18,15 @@ import org.obiba.magma.ValueTable;
 import org.obiba.magma.security.SecuredDatasource;
 import org.obiba.magma.support.MagmaEngineReferenceResolver;
 import org.obiba.magma.support.MagmaEngineTableResolver;
+import org.obiba.opal.core.domain.ProjectsState;
+import org.obiba.opal.core.domain.ProjectsState.State;
 import org.obiba.opal.shell.CommandJob;
 import org.obiba.opal.shell.CommandRegistry;
 import org.obiba.opal.shell.Dtos;
 import org.obiba.opal.shell.commands.Command;
 import org.obiba.opal.shell.commands.options.*;
-import org.obiba.opal.shell.service.CommandJobService;
 import org.obiba.opal.shell.web.*;
 import org.obiba.opal.web.model.Commands;
-import org.obiba.opal.web.model.Commands.CommandStateDto.Status;
 import org.obiba.opal.web.model.Commands.RefreshCommandOptionsDto;
 import org.obiba.opal.web.support.ConflictingRequestException;
 import org.obiba.opal.web.support.InvalidRequestException;
@@ -58,16 +57,15 @@ public class ProjectCommandsResource extends AbstractCommandsResource {
 
   private static final Logger log = LoggerFactory.getLogger(ProjectCommandsResource.class);
 
-  private static final List<String> READ_WRITE_COMMAND_NAMES = Arrays.asList("import", "export", "copy");
-  private static final String REFRESH_COMMAND_NAME = "refresh";
-  private static final List<Status> BLOCKING_STATUSES = Arrays.asList(Status.IN_PROGRESS, Status.NOT_STARTED);
-
   @PathParam("name")
   protected String name;
 
   @Autowired
   @Qualifier("web")
   private CommandRegistry commandRegistry;
+
+  @Autowired
+  private ProjectsState projectsState;
 
   @GET
   public List<Commands.CommandStateDto> getCommands() {
@@ -90,7 +88,7 @@ public class ProjectCommandsResource extends AbstractCommandsResource {
   @POST
   @Path("/_import")
   public Response importData(Commands.ImportCommandOptionsDto options) {
-    if (checkCommandIsBlocked(commandJobService, name, false)) throw new ConflictingRequestException("ProjectMomentarilyNotRefreshable", name);
+    if (checkCommandIsBlocked(name, false)) throw new ConflictingRequestException("ProjectMomentarilyNotRefreshable", name);
 
     if(!name.equals(options.getDestination())) {
       throw new InvalidRequestException("DataCanOnlyBeImportedInCurrentDatasource", name);
@@ -124,7 +122,7 @@ public class ProjectCommandsResource extends AbstractCommandsResource {
   @POST
   @Path("/_copy")
   public Response copyData(Commands.CopyCommandOptionsDto options) {
-    if (checkCommandIsBlocked(commandJobService, name, false)) throw new ConflictingRequestException("ProjectMomentarilyNotRefreshable", name);
+    if (checkCommandIsBlocked(name, false)) throw new ConflictingRequestException("ProjectMomentarilyNotRefreshable", name);
 
     String commandName = "copy";
 
@@ -147,7 +145,7 @@ public class ProjectCommandsResource extends AbstractCommandsResource {
   @POST
   @Path("/_export")
   public Response exportData(Commands.ExportCommandOptionsDto options) {
-    if (checkCommandIsBlocked(commandJobService, name, false)) throw new ConflictingRequestException("ProjectMomentarilyNotRefreshable", name);
+    if (checkCommandIsBlocked(name, false)) throw new ConflictingRequestException("ProjectMomentarilyNotRefreshable", name);
 
     String commandName = "export";
 
@@ -226,7 +224,7 @@ public class ProjectCommandsResource extends AbstractCommandsResource {
   @POST
   @Path("/_refresh")
   public Response refreshProject() {
-    if (checkCommandIsBlocked(commandJobService, name, true)) throw new ConflictingRequestException("ProjectMomentarilyNotRefreshable", name);
+    if (checkCommandIsBlocked(name, true)) throw new ConflictingRequestException("ProjectMomentarilyNotRefreshable", name);
 
     Command<Object> refreshCommand = commandRegistry.newCommand("refresh");
     refreshCommand.setOptions(new RefreshCommandOptionsDtoImpl(RefreshCommandOptionsDto.newBuilder().setProject(name).build()));
@@ -240,33 +238,14 @@ public class ProjectCommandsResource extends AbstractCommandsResource {
     return job;
   }
 
-  private boolean checkCommandIsBlocked(CommandJobService commandJobService, String projectName, boolean forProjectRefresh) {
-    return checkCommandIsBlocked(
-        commandJobService.getHistory().stream()
-            .filter(job -> job.hasProject() && job.getProject().equals(projectName))
-            .collect(Collectors.toList()),
-        projectName,
-        forProjectRefresh
-    );
-  }
+  private boolean checkCommandIsBlocked(String projectName, boolean forProjectRefresh) {
+    String projectState = projectsState.getProjectState(projectName);
 
-  private boolean checkCommandIsBlocked(List<CommandJob> jobs, String projectName, boolean forProjectRefresh) {
-    boolean isBlocked;
     if (forProjectRefresh) {
-      isBlocked = jobs.stream()
-          .filter(job -> projectName.equals(job.getProject()) && (READ_WRITE_COMMAND_NAMES.indexOf(job.getName()) > -1 || REFRESH_COMMAND_NAME.equals(job.getName())))
-          .anyMatch(job -> BLOCKING_STATUSES.indexOf(job.getStatus()) > -1);
+      return !State.READY.name().equals(projectState);
     } else {
-      isBlocked = jobs.stream()
-          .filter(job -> projectName.equals(job.getProject()) && REFRESH_COMMAND_NAME.equals(job.getName()))
-          .anyMatch(job -> BLOCKING_STATUSES.indexOf(job.getStatus()) > -1);
+      return State.REFRESHING.name().equals(projectState);
     }
-
-    if (isBlocked) {
-      log.warn("Project [{}]'s {} command call is blocked.", projectName, forProjectRefresh ? "refresh" : "read/write/copy");
-    }
-
-    return isBlocked;
   }
 
   private void ensureTableValuesAccess(String table) {

--- a/opal-shell/src/main/java/org/obiba/opal/web/shell/ProjectCommandsResource.java
+++ b/opal-shell/src/main/java/org/obiba/opal/web/shell/ProjectCommandsResource.java
@@ -11,7 +11,6 @@ package org.obiba.opal.web.shell;
 
 import com.google.common.collect.Lists;
 import java.util.Arrays;
-import javax.ws.rs.core.Response.ResponseBuilder;
 import org.apache.shiro.SecurityUtils;
 import org.obiba.magma.Datasource;
 import org.obiba.magma.MagmaEngine;
@@ -234,29 +233,6 @@ public class ProjectCommandsResource extends AbstractCommandsResource {
     return launchCommand(refreshCommand);
   }
 
-  @GET
-  @Path("/state")
-  public Response getState() {
-    List<CommandJob> jobs = commandJobService.getHistory().stream()
-        .filter(job -> job.hasProject() && job.getProject()
-            .equals(name)).collect(Collectors.toList());
-
-    boolean isRefreshing = checkCommandIsBlocked(jobs, name, false);
-    boolean isBusy = checkCommandIsBlocked(jobs, name, true);
-
-    ResponseBuilder responseBuilder = Response.ok();
-
-    if (isBusy) {
-      responseBuilder.entity(State.BUSY.name());
-    } else if (isRefreshing) {
-      responseBuilder.entity(State.REFRESHING.name());
-    } else {
-      responseBuilder.entity(State.READY.name());
-    }
-
-    return responseBuilder.build();
-  }
-
   @Override
   protected CommandJob newCommandJob(String jobName, Command<?> command) {
     CommandJob job = super.newCommandJob(jobName, command);
@@ -341,11 +317,5 @@ public class ProjectCommandsResource extends AbstractCommandsResource {
     return Response.created(
         UriBuilder.fromPath("/").path(WebShellResource.class).path(WebShellResource.class, "getCommand").build(jobId))
         .build();
-  }
-
-  public enum State {
-    BUSY, // project has read, write and refresh commands that are pending or being processed
-    READY,
-    REFRESHING // project only has one refresh command being processed (only one should be present at a time)
   }
 }


### PR DESCRIPTION
related  to  #3453

- moved `/state` resource to be under `/project/{name}` with appropriate permission
- project state is managed by a singleton
- state is queried on datasource, table,  variable selection and project administration page navigation
- added help message under refresh button