### PR TITLE
Converted BaseResource to an abstract class

### DIFF
--- a/opal-core-ws/src/main/java/org/obiba/opal/web/BaseResource.java
+++ b/opal-core-ws/src/main/java/org/obiba/opal/web/BaseResource.java
@@ -13,16 +13,16 @@ package org.obiba.opal.web;
 import jakarta.ws.rs.OPTIONS;
 import jakarta.ws.rs.core.Response;
 
-public interface BaseResource {
+public abstract class BaseResource {
 
   /**
-   * Default OPTIONS implementation, so that {@link org.obiba.opal.web.security.AuthorizationInterceptor} can
+   * OPTIONS implementation, so that {@link org.obiba.opal.web.security.AuthorizationInterceptor} can
    * set the Allow header with appropriate HTTP methods.
    *
    * @return
    */
   @OPTIONS
-  default Response getOptions() {
+  public Response getOptions() {
     return Response.ok().build();
   }
 }

--- a/opal-core-ws/src/main/java/org/obiba/opal/web/magma/AbstractValueTableResource.java
+++ b/opal-core-ws/src/main/java/org/obiba/opal/web/magma/AbstractValueTableResource.java
@@ -17,13 +17,14 @@ import org.obiba.magma.ValueTable;
 import org.obiba.magma.Variable;
 import org.obiba.magma.VariableEntity;
 import org.obiba.magma.js.views.JavascriptClause;
+import org.obiba.opal.web.BaseResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 
 import jakarta.annotation.Nullable;
 import java.util.*;
 
-abstract class AbstractValueTableResource {
+abstract class AbstractValueTableResource extends BaseResource {
 
   private ValueTable valueTable;
 

--- a/opal-core-ws/src/main/java/org/obiba/opal/web/magma/ValueSetsResource.java
+++ b/opal-core-ws/src/main/java/org/obiba/opal/web/magma/ValueSetsResource.java
@@ -20,9 +20,8 @@ import jakarta.ws.rs.core.UriInfo;
 
 import org.obiba.magma.ValueTable;
 import org.obiba.magma.VariableValueSource;
-import org.obiba.opal.web.BaseResource;
 
-public interface ValueSetsResource extends BaseResource {
+public interface ValueSetsResource {
 
   void setValueTable(ValueTable valueTable);
 

--- a/opal-core-ws/src/main/java/org/obiba/opal/web/project/ProjectResource.java
+++ b/opal-core-ws/src/main/java/org/obiba/opal/web/project/ProjectResource.java
@@ -24,6 +24,7 @@ import org.obiba.opal.core.security.OpalKeyStore;
 import org.obiba.opal.core.service.*;
 import org.obiba.opal.core.service.security.ProjectsKeyStoreService;
 import org.obiba.opal.spi.vcf.VCFStoreService;
+import org.obiba.opal.web.BaseResource;
 import org.obiba.opal.web.model.Projects;
 import org.obiba.opal.web.security.KeyStoreResource;
 import org.obiba.opal.web.vcf.VCFStoreResource;
@@ -45,7 +46,7 @@ import java.util.stream.Collectors;
 @Component
 @Scope("request")
 @Path("/project/{name}")
-public class ProjectResource {
+public class ProjectResource extends BaseResource {
 
   private final static Authorizer authorizer = new ShiroAuthorizer();
 

--- a/opal-core-ws/src/main/java/org/obiba/opal/web/project/ProjectsResource.java
+++ b/opal-core-ws/src/main/java/org/obiba/opal/web/project/ProjectsResource.java
@@ -16,6 +16,7 @@ import org.obiba.magma.security.shiro.ShiroAuthorizer;
 import org.obiba.opal.core.domain.Project;
 import org.obiba.opal.core.security.OpalPermissions;
 import org.obiba.opal.core.service.ProjectService;
+import org.obiba.opal.web.BaseResource;
 import org.obiba.opal.web.model.Opal;
 import org.obiba.opal.web.model.Projects;
 import org.obiba.opal.web.security.AuthorizationInterceptor;
@@ -34,7 +35,7 @@ import java.util.regex.Pattern;
 
 @Component
 @Path("/projects")
-public class ProjectsResource {
+public class ProjectsResource extends BaseResource {
 
   private final static Authorizer authorizer = new ShiroAuthorizer();
 

--- a/opal-core-ws/src/main/java/org/obiba/opal/web/project/resource/ProjectResourceReferenceResource.java
+++ b/opal-core-ws/src/main/java/org/obiba/opal/web/project/resource/ProjectResourceReferenceResource.java
@@ -29,7 +29,7 @@ import jakarta.ws.rs.core.Response;
 
 @Component
 @Path("/project/{project}/resource/{name}")
-public class ProjectResourceReferenceResource implements BaseResource {
+public class ProjectResourceReferenceResource extends BaseResource {
 
   private final static Authorizer authorizer = new ShiroAuthorizer();
 

--- a/opal-core-ws/src/main/java/org/obiba/opal/web/project/resource/ProjectResourceReferencesResource.java
+++ b/opal-core-ws/src/main/java/org/obiba/opal/web/project/resource/ProjectResourceReferencesResource.java
@@ -33,7 +33,7 @@ import java.util.stream.StreamSupport;
 
 @Component
 @Path("/project/{name}/resources")
-public class ProjectResourceReferencesResource implements BaseResource {
+public class ProjectResourceReferencesResource extends BaseResource {
 
   private final static Authorizer authorizer = new ShiroAuthorizer();
 

--- a/opal-core-ws/src/main/java/org/obiba/opal/web/security/AbstractPermissionsResource.java
+++ b/opal-core-ws/src/main/java/org/obiba/opal/web/security/AbstractPermissionsResource.java
@@ -19,7 +19,7 @@ import java.util.Collection;
 
 import static org.obiba.opal.core.domain.security.SubjectAcl.SubjectType;
 
-public abstract class AbstractPermissionsResource implements BaseResource {
+public abstract class AbstractPermissionsResource extends BaseResource {
 
   public static final String DOMAIN = "opal";
 

--- a/opal-shell/src/main/java/org/obiba/opal/web/shell/AbstractCommandsResource.java
+++ b/opal-shell/src/main/java/org/obiba/opal/web/shell/AbstractCommandsResource.java
@@ -18,7 +18,7 @@ import org.obiba.opal.shell.service.CommandJobService;
 import org.obiba.opal.web.BaseResource;
 import org.springframework.beans.factory.annotation.Autowired;
 
-public abstract class AbstractCommandsResource implements BaseResource {
+public abstract class AbstractCommandsResource extends BaseResource {
 
   protected CommandJobService commandJobService;
 

--- a/opal-shell/src/main/java/org/obiba/opal/web/shell/ProjectCommandsResource.java
+++ b/opal-shell/src/main/java/org/obiba/opal/web/shell/ProjectCommandsResource.java
@@ -30,7 +30,7 @@ import java.util.List;
 @Scope("request")
 @Path("/project/{name}/commands")
 @SuppressWarnings("OverlyCoupledClass")
-public class ProjectCommandsResource implements BaseResource {
+public class ProjectCommandsResource extends BaseResource {
 
   private static final Logger log = LoggerFactory.getLogger(ProjectCommandsResource.class);
 

--- a/opal-shell/src/main/java/org/obiba/opal/web/shell/RClusterCommandsResource.java
+++ b/opal-shell/src/main/java/org/obiba/opal/web/shell/RClusterCommandsResource.java
@@ -29,7 +29,7 @@ import java.util.List;
 @Component
 @Scope("request")
 @Path("/service/r/cluster/{cname}/commands")
-public class RClusterCommandsResource implements BaseResource {
+public class RClusterCommandsResource extends BaseResource {
 
   private static final Logger log = LoggerFactory.getLogger(RClusterCommandsResource.class);
 


### PR DESCRIPTION
The reason is that `@Transactional` and an interface with a `default` implementation causes an error, for example `@GET` endpint was reported to be not part of the resource!

Possible explanation: *When you use the `@Transactional` annotation, it typically creates a proxy around the object to manage transactions. However, default methods in interfaces don't work seamlessly with this proxy mechanism.*

> There are still issues with OPTIONS compared to the older version.  For example `/datasource/CLS/table/Wave1/variables` still only returns OPTIONS!