### PR TITLE
adds smtp security params

### DIFF
--- a/opal-core/src/main/resources/META-INF/defaults.properties
+++ b/opal-core/src/main/resources/META-INF/defaults.properties
@@ -46,6 +46,9 @@ org.obiba.opal.smtp.from=opal@obiba.org
 org.obiba.opal.smtp.auth=false
 org.obiba.opal.smtp.username=
 org.obiba.opal.smtp.password=
+org.obiba.opal.smtp.starttls=false
+org.obiba.opal.smtp.ssl=false
+org.obiba.opal.smtp.ssl.protocols=TLSv1.2
 
 # Plugin repository
 org.obiba.opal.plugins.site=https://plugins.obiba.org

--- a/opal-core/src/main/resources/spring/opal-core/email.xml
+++ b/opal-core/src/main/resources/spring/opal-core/email.xml
@@ -21,6 +21,9 @@
         <property name="properties">
           <props>
             <prop key="mail.smtp.auth">${org.obiba.opal.smtp.auth}</prop>
+            <prop key="mail.smtp.starttls.enable">${org.obiba.opal.smtp.starttls}</prop>
+            <prop key="mail.smtp.ssl.enable">${org.obiba.opal.smtp.ssl}</prop>
+            <prop key="mail.smtp.ssl.protocols">${org.obiba.opal.smtp.ssl.protocols}</prop>
           </props>
         </property>
         <property name="location" value="file:${OPAL_HOME}/conf/smtp.properties"/>

--- a/opal-server/src/main/conf/opal-config.properties
+++ b/opal-server/src/main/conf/opal-config.properties
@@ -94,6 +94,12 @@
 #org.obiba.opal.smtp.auth=false
 #org.obiba.opal.smtp.username=
 #org.obiba.opal.smtp.password=
+#org.obiba.opal.smtp.starttls=false
+#org.obiba.opal.smtp.ssl=false
+
+# Specifies the SSL protocols that will be enabled for SSL connections. The property value is a whitespace separated list:
+# SSLv2Hello SSLv3 TLSv1 TLSv1.1 TLSv1.2
+#org.obiba.opal.smtp.ssl.protocols=TLSv1.2
 
 ##
 # R server settings


### PR DESCRIPTION
Hi,
In some scenarios, the email sending service requires a secure connection.
After trying several ways to modify the Opal configuration file (opal-config.properties) or pass JAVA_OPTS arguments, the only way I found to make the email work with SSL was by applying these modifications.

Thanks!