### PR TITLE
Cleanup selections when confirmation is cancelled, added search bar

### DIFF
--- a/opal-ui/src/i18n/en/index.js
+++ b/opal-ui/src/i18n/en/index.js
@@ -970,6 +970,7 @@ export default {
   export: 'Export',
   extract_archive_password_hint: "The password to extract the archive's content, if applicable.",
   extract: 'Extract',
+  file_folder_search: 'Search files and folders',
   field_separator: 'Field separator',
   file_already_exists: 'File already exists',
   file_selection: 'File selection',

--- a/opal-ui/src/i18n/fr/index.js
+++ b/opal-ui/src/i18n/fr/index.js
@@ -970,6 +970,7 @@ export default {
   export: 'Exporter',
   extract_archive_password_hint: "Le mot de passe pour extraire le contenu de l'archive, si applicable.",
   extract: 'Extraire',
+  file_folder_search: 'Rechercher des fichiers et dossiers',
   field_separator: 'Séparateur de champ',
   file_already_exists: 'Ce fichier existe déjà',
   file_selection: 'Sélection de fichier',

--- a/opal-ui/src/utils/strings.ts
+++ b/opal-ui/src/utils/strings.ts
@@ -32,3 +32,8 @@ export function flattenObjectToString(object: any, icase = true): string {
   result = result.trim();
   return icase ? result.toLowerCase() : result;
 }
+
+export const includesToken = (source: string, token: string, ignoreCase = true) => {
+  if (!source || !token) return true
+  return ignoreCase ? source.toLowerCase().includes(token.toLowerCase()) : source.includes(token);
+};


### PR DESCRIPTION
Fixes: #3951 and #3951

- Added a search bar in FileSelect and FileView.
- Removed `..` that was confusing many people. Breadcrumb is the way to go back up the hierarchy as in the old Opal and many file browsers.