### PR TITLE
fix: keep original data type when exporting temporal variables with categories 

### DIFF
--- a/opal-r/src/main/java/org/obiba/opal/r/magma/util/DateRange.java
+++ b/opal-r/src/main/java/org/obiba/opal/r/magma/util/DateRange.java
@@ -1,39 +1,48 @@
 package org.obiba.opal.r.magma.util;
 
+import com.google.common.collect.Lists;
 import org.obiba.magma.Value;
 import org.obiba.magma.type.DateType;
 
 import java.util.List;
-import java.util.Objects;
 
 public class DateRange implements Range {
-  private final List<String> missingCats;
 
-  private final List<Value> naValues;
+  private List<String> naValues;
+  private List<Value> naRange;
 
   public DateRange(List<String> missingCats) {
-    this.missingCats = missingCats;
-    this.naValues = missingCats.stream().map(this::makeDate).filter(Objects::nonNull).filter(val -> !val.isNull()).sorted().toList();
+    this.naValues = Lists.newArrayList();
+    this.naRange = Lists.newArrayList();
+    missingCats.forEach((name) -> {
+      Value val = makeDate(name);
+      if (val != null && !val.isNull()) {
+        naValues.add(name);
+        naRange.add(val);
+      }
+    });
+    naValues = naValues.stream().sorted().toList();
+    naRange = naRange.stream().sorted().toList();
   }
 
   @Override
   public boolean hasRange() {
-    return !naValues.isEmpty();
+    return !naRange.isEmpty();
   }
 
   @Override
   public String getRangeMin() {
-    return naValues.getFirst().toString();
+    return String.format("'%s'", naRange.getFirst().toString());
   }
 
   @Override
   public String getRangeMax() {
-    return naValues.getLast().toString();
+    return String.format("'%s'", naRange.getLast().toString());
   }
 
   @Override
   public List<String> getMissingCats() {
-    return missingCats;
+    return naValues;
   }
 
   @Override

--- a/opal-r/src/main/java/org/obiba/opal/r/magma/util/DateRange.java
+++ b/opal-r/src/main/java/org/obiba/opal/r/magma/util/DateRange.java
@@ -1,0 +1,51 @@
+package org.obiba.opal.r.magma.util;
+
+import org.obiba.magma.Value;
+import org.obiba.magma.type.DateType;
+
+import java.util.List;
+import java.util.Objects;
+
+public class DateRange implements Range {
+  private final List<String> missingCats;
+
+  private final List<Value> naValues;
+
+  public DateRange(List<String> missingCats) {
+    this.missingCats = missingCats;
+    this.naValues = missingCats.stream().map(this::makeDate).filter(Objects::nonNull).filter(val -> !val.isNull()).sorted().toList();
+  }
+
+  @Override
+  public boolean hasRange() {
+    return !naValues.isEmpty();
+  }
+
+  @Override
+  public String getRangeMin() {
+    return naValues.getFirst().toString();
+  }
+
+  @Override
+  public String getRangeMax() {
+    return naValues.getLast().toString();
+  }
+
+  @Override
+  public List<String> getMissingCats() {
+    return missingCats;
+  }
+
+  @Override
+  public String toString() {
+    return "na_values=" + naValues;
+  }
+
+  private Value makeDate(String valStr) {
+    try {
+      return DateType.get().valueOf(valStr);
+    } catch (Exception e) {
+      return null;
+    }
+  }
+}

--- a/opal-r/src/main/java/org/obiba/opal/r/magma/util/DateTimeRange.java
+++ b/opal-r/src/main/java/org/obiba/opal/r/magma/util/DateTimeRange.java
@@ -1,49 +1,55 @@
 package org.obiba.opal.r.magma.util;
 
+import com.google.common.collect.Lists;
 import org.obiba.magma.Value;
 import org.obiba.magma.type.DateTimeType;
 
 import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.List;
-import java.util.Objects;
 
 public class DateTimeRange implements Range {
   private static final SimpleDateFormat NO_TIMEZONE = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 
-  private final List<String> missingCats;
-
-  private final List<Value> naValues;
+  private List<String> naValues;
+  private List<Value> naRange;
 
   public DateTimeRange(List<String> missingCats) {
-    this.missingCats = missingCats;
-    this.naValues = missingCats.stream().map(this::makeDate).filter(Objects::nonNull).filter(val -> !val.isNull()).sorted().toList();
+    this.naValues = Lists.newArrayList();
+    this.naRange = Lists.newArrayList();
+    missingCats.forEach((name) -> {
+      Value val = makeDate(name);
+      if (val != null && !val.isNull()) {
+        naValues.add(name);
+        naRange.add(val);
+      }
+    });
+    naValues = naValues.stream().sorted().toList();
+    naRange = naRange.stream().sorted().toList();
   }
 
   @Override
   public boolean hasRange() {
-    return !naValues.isEmpty();
+    return !naRange.isEmpty();
   }
 
   @Override
   public String getRangeMin() {
-    return NO_TIMEZONE.format(naValues.getFirst().getValue());
+    return String.format("'%s'", NO_TIMEZONE.format(naRange.getFirst().getValue()));
   }
 
   @Override
   public String getRangeMax() {
-    return NO_TIMEZONE.format(naValues.getLast().getValue());
+    return String.format("'%s'", NO_TIMEZONE.format(naRange.getLast().getValue()));
   }
 
   @Override
   public List<String> getMissingCats() {
-    return missingCats;
+    return naValues;
   }
-
 
   @Override
   public String toString() {
-    return "na_values=" + naValues.stream().map(val -> NO_TIMEZONE.format(val.getValue())).toList();
+    return "na_values=" + naValues;
   }
 
   private Value makeDate(String valStr) {

--- a/opal-r/src/main/java/org/obiba/opal/r/magma/util/DateTimeRange.java
+++ b/opal-r/src/main/java/org/obiba/opal/r/magma/util/DateTimeRange.java
@@ -1,0 +1,56 @@
+package org.obiba.opal.r.magma.util;
+
+import org.obiba.magma.Value;
+import org.obiba.magma.type.DateTimeType;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+
+public class DateTimeRange implements Range {
+  private static final SimpleDateFormat NO_TIMEZONE = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+
+  private final List<String> missingCats;
+
+  private final List<Value> naValues;
+
+  public DateTimeRange(List<String> missingCats) {
+    this.missingCats = missingCats;
+    this.naValues = missingCats.stream().map(this::makeDate).filter(Objects::nonNull).filter(val -> !val.isNull()).sorted().toList();
+  }
+
+  @Override
+  public boolean hasRange() {
+    return !naValues.isEmpty();
+  }
+
+  @Override
+  public String getRangeMin() {
+    return NO_TIMEZONE.format(naValues.getFirst().getValue());
+  }
+
+  @Override
+  public String getRangeMax() {
+    return NO_TIMEZONE.format(naValues.getLast().getValue());
+  }
+
+  @Override
+  public List<String> getMissingCats() {
+    return missingCats;
+  }
+
+
+  @Override
+  public String toString() {
+    return "na_values=" + naValues.stream().map(val -> NO_TIMEZONE.format(val.getValue())).toList();
+  }
+
+  private Value makeDate(String valStr) {
+    try {
+      return DateTimeType.get().valueOf(valStr);
+    } catch (Exception e) {
+      return null;
+    }
+  }
+}

--- a/opal-r/src/main/java/org/obiba/opal/r/magma/util/DoubleRange.java
+++ b/opal-r/src/main/java/org/obiba/opal/r/magma/util/DoubleRange.java
@@ -19,11 +19,11 @@ public class DoubleRange extends NumberRange {
   }
 
   public double getMin() {
-    return naRange.get(0).doubleValue();
+    return naRange.getFirst().doubleValue();
   }
 
   public double getMax() {
-    return naRange.get(naRange.size() - 1).doubleValue();
+    return naRange.getLast().doubleValue();
   }
 
   @Override

--- a/opal-r/src/main/java/org/obiba/opal/r/magma/util/IntegerRange.java
+++ b/opal-r/src/main/java/org/obiba/opal/r/magma/util/IntegerRange.java
@@ -19,11 +19,11 @@ public class IntegerRange extends NumberRange {
   }
 
   public int getMin() {
-    return naRange.get(0).intValue();
+    return naRange.getFirst().intValue();
   }
 
   public int getMax() {
-    return naRange.get(naRange.size() - 1).intValue();
+    return naRange.getLast().intValue();
   }
 
   @Override

--- a/opal-r/src/main/java/org/obiba/opal/r/magma/util/NumberRange.java
+++ b/opal-r/src/main/java/org/obiba/opal/r/magma/util/NumberRange.java
@@ -16,21 +16,19 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-public abstract class NumberRange {
-  private final List<String> cats;
+public abstract class NumberRange implements Range {
   private final List<String> missingCats;
 
   protected List<Number> naValues;
   protected List<Number> naRange;
 
   public NumberRange(List<String> cats, List<String> missingCats) {
-    this.cats = cats;
     this.missingCats = missingCats;
     this.naValues = missingCats.stream().map(this::makeNumber).filter(Objects::nonNull).sorted().collect(Collectors.toList());
     this.naRange = Lists.newArrayList();
 
-    // find longuest range
-    List<Number> nums = cats.stream().map(this::makeNumber).filter(Objects::nonNull).sorted().collect(Collectors.toList());
+    // find longest range
+    List<Number> nums = cats.stream().map(this::makeNumber).filter(Objects::nonNull).sorted().toList();
     List<Number> tmpRange = Lists.newArrayList();
 
     for (Number value : nums) {
@@ -58,18 +56,22 @@ public abstract class NumberRange {
     missingCats.removeAll(toRemove);
   }
 
+  @Override
   public boolean hasRange() {
     return !naRange.isEmpty();
   }
 
-  public Number getRangeMin() {
-    return hasRange() ? naRange.get(0) : null;
+  @Override
+  public String getRangeMin() {
+    return hasRange() ? naRange.getFirst().toString() : null;
   }
 
-  public Number getRangeMax() {
-    return hasRange() ? naRange.get(naRange.size() - 1) : null;
+  @Override
+  public String getRangeMax() {
+    return hasRange() ? naRange.getLast().toString() : null;
   }
 
+  @Override
   public List<String> getMissingCats() {
     return missingCats;
   }

--- a/opal-r/src/main/java/org/obiba/opal/r/magma/util/Range.java
+++ b/opal-r/src/main/java/org/obiba/opal/r/magma/util/Range.java
@@ -1,0 +1,14 @@
+package org.obiba.opal.r.magma.util;
+
+import java.util.List;
+
+public interface Range {
+
+  boolean hasRange();
+
+  String getRangeMin();
+
+  String getRangeMax();
+
+  List<String> getMissingCats();
+}

--- a/opal-r/src/test/java/org/obiba/opal/r/magma/VectorTypeTest.java
+++ b/opal-r/src/test/java/org/obiba/opal/r/magma/VectorTypeTest.java
@@ -3,9 +3,7 @@ package org.obiba.opal.r.magma;
 import org.fest.util.Lists;
 import org.junit.Assert;
 import org.junit.Test;
-import org.obiba.opal.r.magma.util.DoubleRange;
-import org.obiba.opal.r.magma.util.IntegerRange;
-import org.obiba.opal.r.magma.util.NumberRange;
+import org.obiba.opal.r.magma.util.*;
 
 public class VectorTypeTest {
 
@@ -39,4 +37,27 @@ public class VectorTypeTest {
     Assert.assertEquals("na_range=[2000] na_values=[]", res.toString());
   }
 
+  @Test
+  public void findDateRangeTest() {
+    Range res = new DateRange(Lists.newArrayList("1871-01-29", "1918-11-11", "1945-05-08"));
+    Assert.assertEquals("na_values=[1871-01-29, 1918-11-11, 1945-05-08]", res.toString());
+
+    res = new DateRange(Lists.newArrayList("1945-05-08", "1871-01-29", "1918-11-11"));
+    Assert.assertEquals("na_values=[1871-01-29, 1918-11-11, 1945-05-08]", res.toString());
+
+    res = new DateRange(Lists.newArrayList("1918 11 11", "1871/01/29", "08.05.1945"));
+    Assert.assertEquals("na_values=[1871-01-29, 1918-11-11, 1945-05-08]", res.toString());
+  }
+
+  @Test
+  public void findDateTimeRangeTest() {
+    Range res = new DateTimeRange(Lists.newArrayList("1871-01-29 10:11:12", "1918-11-11 11:11:11", "1945-05-08 22:12:24"));
+    Assert.assertEquals("na_values=[1871-01-29 10:11:12, 1918-11-11 11:11:11, 1945-05-08 22:12:24]", res.toString());
+
+    res = new DateTimeRange(Lists.newArrayList("1945-05-08", "1871-01-29 10:11:12", "1918-11-11"));
+    Assert.assertEquals("na_values=[1871-01-29 10:11:12, 1918-11-11 00:00:00, 1945-05-08 00:00:00]", res.toString());
+
+    res = new DateTimeRange(Lists.newArrayList("1918 11 11", "1871/01/29 10:11:12", "08.05.1945"));
+    Assert.assertEquals("na_values=[1871-01-29 10:11:12, 1918-11-11 00:00:00]", res.toString());
+  }
 }

--- a/opal-r/src/test/java/org/obiba/opal/r/magma/VectorTypeTest.java
+++ b/opal-r/src/test/java/org/obiba/opal/r/magma/VectorTypeTest.java
@@ -46,7 +46,7 @@ public class VectorTypeTest {
     Assert.assertEquals("na_values=[1871-01-29, 1918-11-11, 1945-05-08]", res.toString());
 
     res = new DateRange(Lists.newArrayList("1918 11 11", "1871/01/29", "08.05.1945"));
-    Assert.assertEquals("na_values=[1871-01-29, 1918-11-11, 1945-05-08]", res.toString());
+    Assert.assertEquals("na_values=[08.05.1945, 1871/01/29, 1918 11 11]", res.toString());
   }
 
   @Test
@@ -55,9 +55,9 @@ public class VectorTypeTest {
     Assert.assertEquals("na_values=[1871-01-29 10:11:12, 1918-11-11 11:11:11, 1945-05-08 22:12:24]", res.toString());
 
     res = new DateTimeRange(Lists.newArrayList("1945-05-08", "1871-01-29 10:11:12", "1918-11-11"));
-    Assert.assertEquals("na_values=[1871-01-29 10:11:12, 1918-11-11 00:00:00, 1945-05-08 00:00:00]", res.toString());
+    Assert.assertEquals("na_values=[1871-01-29 10:11:12, 1918-11-11, 1945-05-08]", res.toString());
 
     res = new DateTimeRange(Lists.newArrayList("1918 11 11", "1871/01/29 10:11:12", "08.05.1945"));
-    Assert.assertEquals("na_values=[1871-01-29 10:11:12, 1918-11-11 00:00:00]", res.toString());
+    Assert.assertEquals("na_values=[1871/01/29 10:11:12, 1918 11 11]", res.toString());
   }
 }


### PR DESCRIPTION
Previously: a date or datetime variable was downgraded to text when assigned to R because Date and Posixct objects cannot be labelled. 
Now: the the original data type is kept, the R column is not labelled and instead `na_values` and `na_range` attributes are added. 
Limitations: these `na_values` and `na_range` attributes could be potentially used when `haven` writes to SPSS, but it is not the case because of a limited sav format support from haven.
