### PR TITLE
Add exec to startup scripts for graceful Java shutdown and OrientDB cleanup

### DIFF
--- a/opal-server/src/main/bin/opal
+++ b/opal-server/src/main/bin/opal
@@ -69,4 +69,4 @@ JAVA_DEBUG=-agentlib:jdwp=transport=dt_socket,server=y,address=8000,suspend=n
 # Add $JAVA_DEBUG to this line to enable remote JVM debugging (for developers)
 APP_OPTS="${JAVA_OPTS} ${JAVA_DEBUG} -cp $CLASSPATH -DOPAL_HOME=${OPAL_HOME} -DOPAL_DIST=${OPAL_DIST} -DOPAL_LOG=${OPAL_LOG} -Dpolyglot.log.file=${OPAL_LOG}/polyglot.log -Dpolyglot.engine.WarnInterpreterOnly=false"
 $JAVA $APP_OPTS  org.obiba.opal.server.OpalServer --upgrade
-$JAVA $APP_OPTS org.obiba.opal.server.OpalServer
+exec $JAVA $APP_OPTS org.obiba.opal.server.OpalServer

--- a/opal-server/src/main/deb/systemd/start.sh
+++ b/opal-server/src/main/deb/systemd/start.sh
@@ -28,4 +28,4 @@ done < <(find "${OPAL_HOME}/plugins/" -type d -name lib | grep -v ".archive")
 
 APP_OPTS="${JAVA_ARGS} -cp ${CLASSPATH} -DOPAL_HOME=${OPAL_HOME} -DOPAL_DIST=${OPAL_DIST} -DOPAL_LOG=${OPAL_LOG} -Dpolyglot.log.file=${OPAL_LOG}/polyglot.log -Dpolyglot.engine.WarnInterpreterOnly=false"
 $JAVA $APP_OPTS org.obiba.opal.server.OpalServer --upgrade
-$JAVA $APP_OPTS org.obiba.opal.server.OpalServer
+exec $JAVA $APP_OPTS org.obiba.opal.server.OpalServer

--- a/opal-server/src/main/rpm/start.sh
+++ b/opal-server/src/main/rpm/start.sh
@@ -28,4 +28,4 @@ done < <(find "${OPAL_HOME}/plugins/" -type d -name lib | grep -v ".archive")
 
 APP_OPTS="${JAVA_ARGS} -cp ${CLASSPATH} -DOPAL_HOME=${OPAL_HOME} -DOPAL_DIST=${OPAL_DIST} -DOPAL_LOG=${OPAL_LOG} -Dpolyglot.log.file=${OPAL_LOG}/polyglot.log -Dpolyglot.engine.WarnInterpreterOnly=false"
 $JAVA $APP_OPTS org.obiba.opal.server.OpalServer --upgrade
-$JAVA $APP_OPTS org.obiba.opal.server.OpalServer
+exec $JAVA $APP_OPTS org.obiba.opal.server.OpalServer


### PR DESCRIPTION
Ensures SIGTERM reach Java process directly (PID 1) for proper shutdown and OrientDB closure - prevents database corruption on container/service stop.

AS a safeguard, add this to docker-compose file, wait 30s:
```
    stop_grace_period: 30s
```

#### Before fix:
```
>docker compose exec  opal  ps -aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
opal           1  0.3  0.0   7472  3712 ?        Ss   22:05   0:00 /bin/bash /opt/opal/bin/start.sh
opal          57  0.0  0.0   7856  4480 ?        S    22:05   0:00 /bin/bash /usr/share/opal/bin/opal
opal         127  313  0.7 6231340 230208 ?      Sl   22:05   0:04 java -Xms1G -Xmx2G -XX:+UseG1GC -agentlib:jdwp=transport=dt_socket,server=y,address=8000,suspend=n -cp /srv/conf:/usr/share/opal/lib/*:/srv/plugins/opa
opal         165 40.9  0.0  38224 28544 ?        S    22:05   0:00 /usr/bin/python3 /usr/local/bin/opal rest -o http://localhost:8080 -u administrator -p password -m GET /system/databases
```

#### After fix
```
>docker compose exec  opal  ps -aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
opal           1  180  3.0 8288960 1012452 ?     Ssl  22:06   0:25 java -Xms1G -Xmx2G -XX:+UseG1GC -agentlib:jdwp=transport=dt_socket,server=y,address=8000,suspend=n -cp /srv/conf:/usr/share/opal/lib/*:/srv/plugins/opa

```