### PR TITLE
feat: upgrade OrientDB to 3.2.55 and GraalVM to 25.3.4.1, add JDK 25 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      # a JDK 25 failure must not cancel the JDK 21 leg, which is the one that deploys
+      fail-fast: false
       matrix:
-        java-version: [21]
+        java-version: [21, 25]
 
     steps:
       - name: Checkout repository
@@ -37,8 +39,9 @@ jobs:
           path: |
             ~/.m2
             ~/.cache
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-maven-jdk${{ matrix.java-version }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
+            ${{ runner.os }}-maven-jdk${{ matrix.java-version }}-
             ${{ runner.os }}-maven-
 
       - name: Set up Maven settings
@@ -47,7 +50,7 @@ jobs:
           cp .settings.xml ~/.m2/settings.xml
 
       - name: Deploy Snapshot
-        if: github.ref == 'refs/heads/snapshot' && github.event_name == 'push'
+        if: github.ref == 'refs/heads/snapshot' && github.event_name == 'push' && matrix.java-version == 21
         run: mvn -U deploy
         env:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -55,7 +58,7 @@ jobs:
           ARTIFACTORY_PWD: ${{ secrets.ARTIFACTORY_PWD }}
 
       - name: Deploy Release
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') && matrix.java-version == 21
         run: mvn -Prelease deploy
         env:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -63,5 +66,5 @@ jobs:
           ARTIFACTORY_PWD: ${{ secrets.ARTIFACTORY_PWD }}
 
       - name: Maven Install (non-snapshot, non-tag)
-        if: github.ref != 'refs/heads/snapshot' && !startsWith(github.ref, 'refs/tags/')
+        if: matrix.java-version != 21 || (github.ref != 'refs/heads/snapshot' && !startsWith(github.ref, 'refs/tags/'))
         run: mvn -U install

--- a/opal-r/pom.xml
+++ b/opal-r/pom.xml
@@ -73,6 +73,7 @@
     <dependency>
       <groupId>org.graalvm.js</groupId>
       <artifactId>js</artifactId>
+      <type>pom</type>
     </dependency>
 
     <!-- R dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <ehcache.version>3.10.8</ehcache.version>
     <fest.version>2.0M10</fest.version>
     <findbugs.version>3.0.1</findbugs.version>
-    <graalvm.version>21.3.5</graalvm.version>
+    <graalvm.version>25.3.4.1</graalvm.version>
     <gson.version>2.8.9</gson.version>
     <guava.version>33.6.0-jre</guava.version>
     <httpclient.version>5.6.3</httpclient.version>
@@ -1226,6 +1226,32 @@
             <groupId>javax.activation</groupId>
             <artifactId>javax.activation-api</artifactId>
           </exclusion>
+          <!-- Opal does not use OrientDB's JS scripting; graal-sdk is kept because
+               orientdb-core references org.graalvm.polyglot.PolyglotException directly -->
+          <exclusion>
+            <groupId>org.graalvm.truffle</groupId>
+            <artifactId>truffle-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.graalvm.js</groupId>
+            <artifactId>js</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.graalvm.js</groupId>
+            <artifactId>js-scriptengine</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.graalvm.regex</groupId>
+            <artifactId>regex</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.graalvm.tools</groupId>
+            <artifactId>profiler</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.graalvm.tools</groupId>
+            <artifactId>chromeinspector</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 
@@ -1238,6 +1264,8 @@
         <groupId>org.graalvm.js</groupId>
         <artifactId>js</artifactId>
         <version>${graalvm.version}</version>
+        <!-- since GraalVM 23.1 this is an aggregator POM (js-language + truffle-runtime) -->
+        <type>pom</type>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     <obiba-commons.version>5.2.1</obiba-commons.version>
     <opal-oda.version>1.2.3</opal-oda.version>
     <opencsv.version>2.3</opencsv.version>
-    <orientdb.version>3.2.45</orientdb.version>
+    <orientdb.version>3.2.55</orientdb.version>
     <ow2-spec.version>1.0.13</ow2-spec.version>
     <postgresql.version>42.7.12</postgresql.version>
     <protobuf-java-format.version>1.2.1-obiba</protobuf-java-format.version>


### PR DESCRIPTION
## Summary

Moves OrientDB to the latest 3.2.x patch, removes the GraalJS artifacts Opal never uses from `orientdb-core`, and upgrades the GraalVM stack that `opal-r` does use so the whole build works on JDK 25. CI now exercises both JDK 21 and JDK 25.

## OrientDB 3.2.45 → 3.2.55

Ten patch releases, and the delta is small: 22 changed files in `orientdb-core`, an identical set of 2856 classes, and byte-identical `javap` signatures for all 23 OrientDB types Opal imports. Storage format `CURRENT_VERSION` stays at 23, so there is no on-disk migration and no one-way door.

The one declared breaking change — a stricter `db.custom.support` gate, extended from `ODocument` into the serializers — does not apply. Every gate sits inside an `OType.CUSTOM` branch, i.e. Java-serialized objects in records, and `OrientDbServiceImpl` round-trips everything through JSON (`document.fromJSON(gson.toJson(obj))`), so no CUSTOM value was ever written to an existing Opal database either.

Worth having: 3.2.53 carries a security fix in network deserialization, and 3.2.54 hardens the binary protocol. One default changed — `memory.pool.limit` is now capped at 1 GB instead of unbounded.

## GraalJS excluded from `orientdb-core`

Opal does not use OrientDB's JS scripting, so `truffle-api`, `js`, `js-scriptengine`, `regex`, `profiler` and `chromeinspector` are excluded from the managed `orientdb-core` dependency. Because the exclusions live in `dependencyManagement`, they also apply through the `orientdb-server` → `orientdb-core` path, so `opal-core-api` is covered without a per-module edit.

`graal-sdk` is deliberately **not** excluded: `orientdb-core` references `org.graalvm.polyglot.PolyglotException` directly, and removing it fails every OrientDB-backed test with `ClassNotFoundException` at Spring context load.

Dropping `js-scriptengine` also removes the JSR-223 factory that made OrientDB initialise Truffle during `OrientDBEmbedded` startup — which died on JDK 24+ with `NoSuchMethodError: sun.misc.Unsafe.ensureClassInitialized`.

## GraalVM 21.3.5 → 25.3.4.1

`opal-r` embeds GraalJS itself (`org.graalvm.polyglot.Context` in `RResourceFactory`/`RResourceProvider`) and hit the same removed-`Unsafe`-method failure on JDK 25. No exclusion can fix that one, so the version moves to GraalVM for JDK 25.

Since GraalVM 23.1, `org.graalvm.js:js` is an aggregator POM rather than a jar, hence the added `<type>pom</type>` — needed in both the managed entry and the `opal-r` declaration, since `dependencyManagement` matches on `groupId:artifactId:type:classifier`.

The existing coordinates are kept: `graal-sdk` 25.3.4.1 still exists and now pulls `org.graalvm.polyglot:polyglot`, which is what supplies `PolyglotException` for OrientDB. Licences are unchanged — `org.graalvm.js:js` is UPL + MIT, the community stack, not GFTC.

All GraalVM 25 jars target class-file major 61 (JDK 17), so **JDK 21 remains supported** — this is not a forced move to 25.

## CI

`java-version` becomes `[21, 25]`. Because the job both builds and deploys, three guards come with it:

- deploy steps pinned to `matrix.java-version == 21`, so snapshots and releases are still published exactly once, from the supported runtime
- `fail-fast: false`, so a JDK 25 failure cannot cancel a deploy in progress
- the Maven Install step now runs on non-deploying JDKs on every ref — otherwise the JDK 25 leg would do nothing on the snapshot branch and on tags
- cache keys scoped per JDK, since two legs now write `~/.m2`

## Testing

| | JDK 21 | JDK 25 |
|---|---|---|
| `opal-core-api`, `opal-core`, `opal-r`, `opal-core-ws`, `opal-shell`, `opal-datashield` | 273 pass | 273 pass |
| Clean `mvn -U clean install` (full reactor) | — | 19/19 modules, 302 tests pass |

Also verified directly on Temurin 25.0.1: an embedded OrientDB 3.2.55 smoke test (create class, unique index, `fromJSON` insert, parameterized query, index lookup, `browseClass`) passes with no polyglot flag needed, and `Context.eval("js", …)` works with the `-Dpolyglot.log.file` / `-Dpolyglot.engine.WarnInterpreterOnly=false` flags already set in `opal-server/src/main/bin/opal`.

## Follow-ups, not in this PR

- Truffle 25 triggers a JDK 25 native-access warning (`System::load` from `com.oracle.truffle.polyglot.JDKSupport`); `--enable-native-access=ALL-UNNAMED` in `JAVA_OPTS` silences it.
- On a stock JDK, GraalJS runs interpreter-only. Unchanged from 21.3.5, so no regression, and `opal-server/src/main/bin/opal` already suppresses the banner via `-Dpolyglot.engine.WarnInterpreterOnly=false`. Note there is no JVM flag that changes this on Temurin: `-XX:+EnableJVMCI` is rejected without `-XX:+UnlockExperimentalVMOptions`, and with JVMCI unlocked Truffle still reports "Optimized Truffle runtime is not available on this JVM" because Temurin ships no Graal JIT backend. The optimizing runtime needs a GraalVM JDK, i.e. a deployment change. Not worth pursuing regardless: `RResourceFactory` creates a fresh `Context` per call and evaluates two short expressions, so no guest code ever gets hot enough for runtime compilation to help.

