### PR TITLE
fix(resources): delete every resource reference of a project, not the visible ones

### DIFF
--- a/opal-core/src/main/java/org/obiba/opal/core/service/ResourceReferenceServiceImpl.java
+++ b/opal-core/src/main/java/org/obiba/opal/core/service/ResourceReferenceServiceImpl.java
@@ -124,17 +124,22 @@ public class ResourceReferenceServiceImpl implements ResourceReferenceService {
 
   @Override
   public void delete(String project, String name) {
-    try {
-      resourceReferenceRepository.deleteByKey(getResourceReference(project, name));
+    resourceReferenceRepository.findByProjectAndName(project, name).ifPresent(reference -> {
+      resourceReferenceRepository.delete(reference);
       subjectAclService.deleteNodePermissions(getPermissionNode(project, name));
-    } catch (NoSuchResourceReferenceException e) {
-      // ignore
-    }
+    });
   }
 
+  /**
+   * Removing the resources of a project is authorized where it is asked for - the web resource, or the deletion of the
+   * project itself - so every reference of the project goes, not only the ones the current subject happens to be able
+   * to view. Filtering a deletion by view permission left behind exactly the rows nobody could see, credentials and
+   * all, and the node permissions removed just below made sure nobody ever would: no later deletion could reach them
+   * either.
+   */
   @Override
   public void deleteAll(String project) {
-    getResourceReferences(project).forEach(resourceReferenceRepository::deleteByKey);
+    resourceReferenceRepository.deleteAll(resourceReferenceRepository.findByProject(project));
     subjectAclService.deleteNodePermissions("/project/" + project + "/resource");
   }
 

--- a/opal-core/src/test/java/org/obiba/opal/core/service/ResourceReferenceServiceImplTest.java
+++ b/opal-core/src/test/java/org/obiba/opal/core/service/ResourceReferenceServiceImplTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2026 OBiBa. All rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.obiba.opal.core.service;
+
+import org.apache.shiro.SecurityUtils;
+import org.apache.shiro.authc.AuthenticationInfo;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.authc.SimpleAuthenticationInfo;
+import org.apache.shiro.authc.UsernamePasswordToken;
+import org.apache.shiro.authz.AuthorizationInfo;
+import org.apache.shiro.authz.SimpleAuthorizationInfo;
+import org.apache.shiro.mgt.DefaultSecurityManager;
+import org.apache.shiro.realm.AuthorizingRealm;
+import org.apache.shiro.subject.PrincipalCollection;
+import org.apache.shiro.subject.Subject;
+import org.apache.shiro.util.ThreadContext;
+import org.easymock.EasyMock;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.obiba.opal.core.domain.ResourceReference;
+import org.obiba.opal.core.repository.ResourceReferenceRepository;
+import org.obiba.opal.core.service.security.CryptoService;
+import org.obiba.opal.core.service.security.SubjectAclService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+/**
+ * Deleting the resources of a project used to go through the listing the read path uses, which hides the references
+ * the current subject cannot view. A subject with project-scoped rather than global permissions therefore left rows
+ * behind - orphaned, credentials and all - and the node permissions removed alongside them meant nobody could see
+ * them afterwards either, so no later deletion could reach them.
+ */
+@ContextConfiguration(classes = ResourceReferenceServiceImplTest.Config.class)
+public class ResourceReferenceServiceImplTest extends AbstractConfigDbTest {
+
+  private static final String PROJECT = "project";
+
+  @Autowired
+  private ResourceReferenceService resourceReferenceService;
+
+  @Autowired
+  private ResourceReferenceRepository resourceReferenceRepository;
+
+  @Before
+  public void setUpReferences() {
+    resourceReferenceRepository.deleteAll();
+    resourceReferenceRepository.upsert(reference("visible"));
+    resourceReferenceRepository.upsert(reference("hidden"));
+  }
+
+  @After
+  public void unbindSubject() {
+    ThreadContext.unbindSubject();
+    ThreadContext.unbindSecurityManager();
+    SecurityUtils.setSecurityManager(null);
+  }
+
+  @Test
+  public void test_delete_all_takes_the_references_the_subject_cannot_view() {
+    login("rest:/project/" + PROJECT + "/resource/visible:GET");
+
+    resourceReferenceService.deleteAll(PROJECT);
+
+    assertThat(resourceReferenceRepository.findByProject(PROJECT)).isEmpty();
+  }
+
+  @Test
+  public void test_delete_all_takes_everything_when_the_subject_can_view_nothing() {
+    // What the project deletion event looks like when the subject that triggered it has no rights on the resources.
+    login();
+
+    resourceReferenceService.deleteAll(PROJECT);
+
+    assertThat(resourceReferenceRepository.findByProject(PROJECT)).isEmpty();
+  }
+
+  @Test
+  public void test_delete_all_leaves_the_references_of_other_projects() {
+    resourceReferenceRepository.upsert(reference("elsewhere", "other"));
+    login("rest:*");
+
+    resourceReferenceService.deleteAll(PROJECT);
+
+    List<ResourceReference> others = resourceReferenceRepository.findByProject("other");
+    assertThat(others).hasSize(1);
+    assertThat(others.get(0).getName()).isEqualTo("elsewhere");
+  }
+
+  @Test
+  public void test_delete_by_name_takes_a_reference_the_subject_cannot_view() {
+    login("rest:/project/" + PROJECT + "/resource/visible:GET");
+
+    resourceReferenceService.delete(PROJECT, "hidden");
+
+    assertThat(resourceReferenceRepository.findByProjectAndName(PROJECT, "hidden").isPresent()).isFalse();
+    assertThat(resourceReferenceRepository.findByProjectAndName(PROJECT, "visible").isPresent()).isTrue();
+  }
+
+  @Test
+  public void test_delete_by_name_of_an_unknown_reference_is_ignored() {
+    login("rest:*");
+
+    resourceReferenceService.delete(PROJECT, "nope");
+
+    assertThat(resourceReferenceRepository.findByProject(PROJECT)).hasSize(2);
+  }
+
+  private void login(String... permissions) {
+    DefaultSecurityManager securityManager = new DefaultSecurityManager(new PermissionsRealm(Set.of(permissions)));
+    SecurityUtils.setSecurityManager(securityManager);
+    Subject subject = new Subject.Builder(securityManager).buildSubject();
+    ThreadContext.bind(subject);
+    subject.login(new UsernamePasswordToken("user", "password"));
+  }
+
+  private ResourceReference reference(String name) {
+    return reference(name, PROJECT);
+  }
+
+  private ResourceReference reference(String name, String project) {
+    ResourceReference reference = new ResourceReference();
+    reference.setProject(project);
+    reference.setName(name);
+    reference.setProvider("provider");
+    reference.setFactory("factory");
+    reference.setEncryptedCredentialsModel("{\"secret\":\"encrypted\"}");
+    return reference;
+  }
+
+  private static class PermissionsRealm extends AuthorizingRealm {
+
+    private final Set<String> permissions;
+
+    private PermissionsRealm(Set<String> permissions) {
+      this.permissions = permissions;
+      setName("test");
+    }
+
+    @Override
+    protected AuthorizationInfo doGetAuthorizationInfo(PrincipalCollection principals) {
+      SimpleAuthorizationInfo info = new SimpleAuthorizationInfo();
+      info.setStringPermissions(permissions);
+      return info;
+    }
+
+    @Override
+    protected AuthenticationInfo doGetAuthenticationInfo(AuthenticationToken token) {
+      return new SimpleAuthenticationInfo(token.getPrincipal(), token.getCredentials(), getName());
+    }
+  }
+
+  @Configuration
+  public static class Config extends AbstractConfigDbTestConfig {
+
+    @Bean
+    public CryptoService cryptoService() {
+      CryptoService mock = EasyMock.createNiceMock(CryptoService.class);
+      EasyMock.expect(mock.encrypt(EasyMock.anyString())).andReturn("encrypted").anyTimes();
+      EasyMock.expect(mock.decrypt(EasyMock.anyString())).andReturn("decrypted").anyTimes();
+      EasyMock.replay(mock);
+      return mock;
+    }
+
+    @Bean
+    public SubjectAclService subjectAclService() {
+      SubjectAclService mock = EasyMock.createNiceMock(SubjectAclService.class);
+      EasyMock.replay(mock);
+      return mock;
+    }
+
+    @Bean
+    public ResourceProvidersService resourceProvidersService() {
+      ResourceProvidersService mock = EasyMock.createNiceMock(ResourceProvidersService.class);
+      EasyMock.replay(mock);
+      return mock;
+    }
+
+    @Bean
+    public ResourceReferenceService resourceReferenceService(ResourceReferenceRepository resourceReferenceRepository) {
+      return new ResourceReferenceServiceImpl(resourceReferenceRepository, cryptoService(), subjectAclService(),
+          resourceProvidersService());
+    }
+  }
+}


### PR DESCRIPTION
Fixes #4188.

`deleteAll(project)` deleted the resource references through `getResourceReferences(project)` — the listing the *read* path uses, which filters out the references the current subject cannot view:

```java
.filter(ref -> canViewResourceReference(project, ref.getName()))
```

So a subject with project-scoped rather than global permissions left rows behind: orphaned, with their encrypted credentials, pointing at a project that no longer exists. The node permission removal on the next line is *not* filtered, so nobody could view them afterwards either — which means no later deletion could reach them. The rows became unreachable through the API.

`deleteAll` is driven by `DatasourceDeletedEvent` as well as by the web resource, so the subject in play is not necessarily the owner of the resources at all.

## The decision this was waiting on

Authorization for removing the resources of a project belongs **at the entry point, not per row**. Both callers already gate it — `ProjectResourceReferencesResource.deleteAll` checks the project is readable and sits behind the REST permission on the path, and project deletion is authorized as project deletion. Re-checking each reference against a *view* permission was answering a different question from the one being asked.

So the cleanup now works from the unfiltered listing:

```java
resourceReferenceRepository.deleteAll(resourceReferenceRepository.findByProject(project));
```

## Also in scope

`delete(String project, String name)` had the identical defect through `getResourceReference`: a subject holding DELETE but not GET on a reference got a silent no-op, because the `NoSuchResourceReferenceException` raised by the visibility check was caught and ignored. It now resolves the reference directly.

This is the "same shape" the issue asked me to check for; say the word if you would rather it went in its own PR.

Preserved deliberately: deleting an unknown reference by name is still ignored, and still leaves its node permissions alone.

## Tests

New `ResourceReferenceServiceImplTest`, five cases, with a real Shiro subject carrying a restricted permission set:

- `deleteAll` takes the reference the subject cannot view;
- `deleteAll` takes everything when the subject can view nothing — the project-deletion event case;
- `deleteAll` leaves other projects alone;
- `delete(project, name)` takes a reference the subject cannot view;
- `delete(project, name)` on an unknown reference is still ignored.

Three of the five fail against the previous implementation; the other two are guards against over-deleting.

## Note

Not a regression from #4187 — `master` before that PR read `getResourceReferences(project).forEach(orientDbService::delete)`, and the filter has been in place since ce7625d42 (Feb 2020). Existing installations may already hold references stranded this way; this stops more from accumulating but does not clean up what is there.

