### PR TITLE
feat(storage): durability and disk space safeguards

### DIFF
--- a/opal-core-api/src/main/java/org/obiba/opal/core/event/DiskLevelChangedEvent.java
+++ b/opal-core-api/src/main/java/org/obiba/opal/core/event/DiskLevelChangedEvent.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 OBiBa. All rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.obiba.opal.core.event;
+
+import org.obiba.opal.core.service.storage.DiskLevel;
+
+/**
+ * Posted when the free space on the volumes Opal writes to crosses a threshold, in either direction. A transition and
+ * not a state: a full disk stays full, and a subscriber that acted on the state would act again every minute.
+ */
+public class DiskLevelChangedEvent {
+
+  private final DiskLevel previousLevel;
+
+  private final DiskLevel level;
+
+  private final String detail;
+
+  public DiskLevelChangedEvent(DiskLevel previousLevel, DiskLevel level, String detail) {
+    this.previousLevel = previousLevel;
+    this.level = level;
+    this.detail = detail;
+  }
+
+  public DiskLevel getPreviousLevel() {
+    return previousLevel;
+  }
+
+  public DiskLevel getLevel() {
+    return level;
+  }
+
+  /**
+   * The volume that decided the level, as a readable line for a log or a message.
+   */
+  public String getDetail() {
+    return detail;
+  }
+}

--- a/opal-core-api/src/main/java/org/obiba/opal/core/service/database/DatabaseRegistry.java
+++ b/opal-core-api/src/main/java/org/obiba/opal/core/service/database/DatabaseRegistry.java
@@ -49,6 +49,13 @@ public interface DatabaseRegistry extends SystemService {
 
   DataSource getDataSource(@NotNull String name, @Nullable String usedByDatasource);
 
+  /**
+   * The data sources that are open right now, and only those. A caller that periodically visits every database — the
+   * H2 checkpointer is the one — must not be the reason a registered database gets opened: that would turn a
+   * maintenance task into "hold a connection pool on every database an administrator ever declared".
+   */
+  Iterable<DataSource> getLoadedDataSources();
+
   void unregister(@NotNull String databaseName, @Nullable String usedByDatasource);
 
   boolean hasIdentifiersDatabase();

--- a/opal-core-api/src/main/java/org/obiba/opal/core/service/storage/DiskLevel.java
+++ b/opal-core-api/src/main/java/org/obiba/opal/core/service/storage/DiskLevel.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 OBiBa. All rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.obiba.opal.core.service.storage;
+
+/**
+ * How much room is left on a volume Opal writes to, as a decision rather than a number.
+ * <p>
+ * {@link #UNKNOWN} is deliberately not the least severe level but outside the scale: it means the volume could not be
+ * measured, and a checker that cannot see must not be the reason a server stops accepting work. It therefore never
+ * satisfies {@link #isAtLeast(DiskLevel)}, whatever is asked of it.
+ */
+public enum DiskLevel {
+
+  UNKNOWN(-1),
+
+  OK(0),
+
+  /**
+   * Reported, and nothing else. There is still room to work.
+   */
+  WARN(1),
+
+  /**
+   * Unbounded, user-initiated, restartable writes are refused: imports, copies, backups, uploads. Reads, login and
+   * configuration writes keep working, which is what leaves an administrator a way in to make room.
+   */
+  DEGRADED(2),
+
+  /**
+   * Running writers are cancelled as well. A cancelled import can be run again; an MVStore that panicked on a full
+   * disk closes itself without persisting, and only a restart brings it back.
+   */
+  CRITICAL(3);
+
+  private final int severity;
+
+  DiskLevel(int severity) {
+    this.severity = severity;
+  }
+
+  public boolean isAtLeast(DiskLevel other) {
+    return severity >= 0 && severity >= other.severity;
+  }
+
+  public boolean isWorseThan(DiskLevel other) {
+    return severity > other.severity;
+  }
+
+  /**
+   * The more severe of two levels. {@link #UNKNOWN} loses to every measured level, so a single volume that cannot be
+   * read does not hide a volume that is genuinely full, nor does it invent a problem on its own.
+   */
+  public DiskLevel worst(DiskLevel other) {
+    return other.severity > severity ? other : this;
+  }
+}

--- a/opal-core-api/src/main/java/org/obiba/opal/core/service/storage/DiskSpaceService.java
+++ b/opal-core-api/src/main/java/org/obiba/opal/core/service/storage/DiskSpaceService.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 OBiBa. All rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.obiba.opal.core.service.storage;
+
+import jakarta.annotation.Nullable;
+import org.obiba.opal.core.service.SystemService;
+
+import java.io.File;
+import java.util.List;
+
+/**
+ * Watches the free space on the volumes Opal writes to, and refuses the large writes before the small ones start
+ * failing.
+ * <p>
+ * The check has to be made before the write, not around it. When an MVStore hits a full disk it calls
+ * {@code panic()} and closes itself without persisting: there is no failed statement to retry and no recovery short of
+ * a restart. Keeping a floor of free space is also what lets the store close cleanly, since compaction and the clean
+ * shutdown mark need somewhere to go.
+ * <p>
+ * The asymmetry between the levels is the design: at {@link DiskLevel#DEGRADED} the writes that are refused are the
+ * unbounded, user-initiated, restartable ones — imports, copies, backups, uploads — while reads, login and
+ * configuration writes keep working. That is what leaves an administrator a way in to make room.
+ */
+public interface DiskSpaceService extends SystemService {
+
+  /**
+   * The most severe level across the watched volumes, from the last sample.
+   */
+  DiskLevel getLevel();
+
+  /**
+   * The last reading of every watched volume, one entry per volume.
+   */
+  List<DiskStatus> getStatuses();
+
+  /**
+   * The last reading of the volume holding the given path, or {@code null} if that volume is not watched.
+   */
+  @Nullable
+  DiskStatus getStatus(File path);
+
+  /**
+   * Whether the levels are acted upon. When false the readings are still taken and reported, and nothing is refused:
+   * the thresholds can then be observed against a real deployment before they start failing jobs.
+   */
+  boolean isEnforced();
+
+  /**
+   * Refuse an unbounded write of unknown size, on the strength of the worst watched volume.
+   *
+   * @throws InsufficientStorageException if the level is {@link DiskLevel#DEGRADED} or worse, and enforcement is on
+   */
+  void checkWritable() throws InsufficientStorageException;
+
+  /**
+   * Refuse a write whose size is known in advance, against the volume it would actually land on. A single large upload
+   * is invisible to a sampler that runs once a minute, so a size that is known up front is checked up front.
+   *
+   * @param path          where the bytes would be written; the volume holding it is what gets checked
+   * @param requiredBytes how many bytes the write needs, before any safety margin
+   * @throws InsufficientStorageException if the write would not leave the reserved floor, and enforcement is on
+   */
+  void checkWritable(File path, long requiredBytes) throws InsufficientStorageException;
+
+  /**
+   * Refuse a write of known size to the Opal file system, which is where uploads, exports and reports go.
+   *
+   * @see #checkWritable(File, long)
+   */
+  void checkFileSystemWritable(long requiredBytes) throws InsufficientStorageException;
+}

--- a/opal-core-api/src/main/java/org/obiba/opal/core/service/storage/DiskStatus.java
+++ b/opal-core-api/src/main/java/org/obiba/opal/core/service/storage/DiskStatus.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 OBiBa. All rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.obiba.opal.core.service.storage;
+
+/**
+ * The last reading taken of one volume Opal writes to. One reading per volume, not per folder: several of the folders
+ * Opal watches are usually on the same mount, and reporting them separately would report the same number several
+ * times.
+ */
+public class DiskStatus {
+
+  /**
+   * What Opal keeps on this volume, as a comma separated list of the watched folder names.
+   */
+  private final String name;
+
+  /**
+   * One of the watched folders on this volume, as an absolute path.
+   */
+  private final String path;
+
+  private final long totalSpace;
+
+  private final long usableSpace;
+
+  private final DiskLevel level;
+
+  public DiskStatus(String name, String path, long totalSpace, long usableSpace, DiskLevel level) {
+    this.name = name;
+    this.path = path;
+    this.totalSpace = totalSpace;
+    this.usableSpace = usableSpace;
+    this.level = level;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public long getTotalSpace() {
+    return totalSpace;
+  }
+
+  public long getUsableSpace() {
+    return usableSpace;
+  }
+
+  public DiskLevel getLevel() {
+    return level;
+  }
+
+  @Override
+  public String toString() {
+    return name + " (" + path + "): " + usableSpace + " of " + totalSpace + " bytes free, " + level;
+  }
+}

--- a/opal-core-api/src/main/java/org/obiba/opal/core/service/storage/InsufficientStorageException.java
+++ b/opal-core-api/src/main/java/org/obiba/opal/core/service/storage/InsufficientStorageException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 OBiBa. All rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.obiba.opal.core.service.storage;
+
+/**
+ * Thrown when a write is refused because the volume it would land on is too close to full. Refusing is the point:
+ * H2 does not fail an individual statement when the disk fills, it panics and closes the store without persisting, so
+ * the only cheap outcome is the one that never gets there.
+ */
+public class InsufficientStorageException extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  public InsufficientStorageException(String message) {
+    super(message);
+  }
+}

--- a/opal-core-api/src/test/java/org/obiba/opal/core/service/storage/DiskLevelTest.java
+++ b/opal-core-api/src/test/java/org/obiba/opal/core/service/storage/DiskLevelTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 OBiBa. All rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.obiba.opal.core.service.storage;
+
+import org.junit.Test;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+public class DiskLevelTest {
+
+  @Test
+  public void test_severity_order() {
+    assertThat(DiskLevel.CRITICAL.isAtLeast(DiskLevel.DEGRADED)).isTrue();
+    assertThat(DiskLevel.DEGRADED.isAtLeast(DiskLevel.DEGRADED)).isTrue();
+    assertThat(DiskLevel.WARN.isAtLeast(DiskLevel.DEGRADED)).isFalse();
+    assertThat(DiskLevel.OK.isAtLeast(DiskLevel.WARN)).isFalse();
+  }
+
+  @Test
+  public void test_unknown_never_blocks() {
+    // a checker that cannot see must not be the reason a server stops accepting work
+    for(DiskLevel level : DiskLevel.values()) {
+      assertThat(DiskLevel.UNKNOWN.isAtLeast(level)).isFalse();
+    }
+  }
+
+  @Test
+  public void test_worst_keeps_the_more_severe() {
+    assertThat(DiskLevel.OK.worst(DiskLevel.CRITICAL)).isEqualTo(DiskLevel.CRITICAL);
+    assertThat(DiskLevel.CRITICAL.worst(DiskLevel.OK)).isEqualTo(DiskLevel.CRITICAL);
+    assertThat(DiskLevel.WARN.worst(DiskLevel.WARN)).isEqualTo(DiskLevel.WARN);
+  }
+
+  @Test
+  public void test_an_unmeasured_volume_neither_hides_nor_invents_a_problem() {
+    // a volume that cannot be read loses to every measured one, in both directions
+    assertThat(DiskLevel.UNKNOWN.worst(DiskLevel.OK)).isEqualTo(DiskLevel.OK);
+    assertThat(DiskLevel.UNKNOWN.worst(DiskLevel.CRITICAL)).isEqualTo(DiskLevel.CRITICAL);
+    assertThat(DiskLevel.OK.worst(DiskLevel.UNKNOWN)).isEqualTo(DiskLevel.OK);
+    // and folding over volumes that could none of them be read stays UNKNOWN
+    assertThat(DiskLevel.UNKNOWN.worst(DiskLevel.UNKNOWN)).isEqualTo(DiskLevel.UNKNOWN);
+  }
+}

--- a/opal-core-ws/src/main/java/org/obiba/opal/web/FilesResource.java
+++ b/opal-core-ws/src/main/java/org/obiba/opal/web/FilesResource.java
@@ -385,15 +385,6 @@ public class FilesResource {
                              @HeaderParam("Content-Length") @DefaultValue("-1") long contentLength)
       throws IOException {
 
-    // The one write whose size is known before it happens. A sampler that runs once a minute cannot see a single 40 GB
-    // upload coming, so the announced length is checked against the volume the file system root is on.
-    try {
-      diskSpaceService.checkFileSystemWritable(contentLength);
-    } catch(InsufficientStorageException e) {
-      log.warn("Upload to {} refused: {}", path, e.getMessage());
-      return Response.status(INSUFFICIENT_STORAGE).entity(e.getMessage()).build();
-    }
-
     String folderPath = getPathOfFileToWrite(path);
     FileObject folder = resolveFileInFileSystem(folderPath);
 
@@ -409,6 +400,15 @@ public class FilesResource {
       return Response.status(Status.BAD_REQUEST)
           .entity("No file has been submitted. Please make sure that you are submitting a file with your request.")
           .build();
+    }
+
+    // The one write whose size is known before it happens. A sampler that runs once a minute cannot see a single 40 GB
+    // upload coming, so the announced length is checked against the volume the file system root is on.
+    try {
+      diskSpaceService.checkFileSystemWritable(contentLength);
+    } catch(InsufficientStorageException e) {
+      log.warn("Upload to {} refused: {}", path, e.getMessage());
+      return Response.status(INSUFFICIENT_STORAGE).entity(e.getMessage()).build();
     }
 
     return doUploadFiles(folderPath, folder, uploadedFiles, uriInfo);

--- a/opal-core-ws/src/main/java/org/obiba/opal/web/FilesResource.java
+++ b/opal-core-ws/src/main/java/org/obiba/opal/web/FilesResource.java
@@ -32,6 +32,8 @@ import org.obiba.opal.core.domain.security.SubjectAcl;
 import org.obiba.opal.core.runtime.OpalFileSystemService;
 import org.obiba.opal.core.security.OpalPermissions;
 import org.obiba.opal.core.service.security.SubjectAclService;
+import org.obiba.opal.core.service.storage.DiskSpaceService;
+import org.obiba.opal.core.service.storage.InsufficientStorageException;
 import org.obiba.opal.web.model.Opal;
 import org.obiba.opal.web.model.Opal.AclAction;
 import org.obiba.opal.web.security.AuthorizationInterceptor;
@@ -68,6 +70,13 @@ public class FilesResource {
 
   private SubjectAclService subjectAclService;
 
+  private DiskSpaceService diskSpaceService;
+
+  /**
+   * HTTP 507, which JAX-RS does not name.
+   */
+  private static final int INSUFFICIENT_STORAGE = 507;
+
   private final FileNameMap mimeTypes = URLConnection.getFileNameMap();;
 
   private final SimpleDateFormat dateTimeFormatter = new SimpleDateFormat("yyyyMMdd_HHmmss");
@@ -86,6 +95,11 @@ public class FilesResource {
   @Autowired
   public void setSubjectAclService(SubjectAclService subjectAclService) {
     this.subjectAclService = subjectAclService;
+  }
+
+  @Autowired
+  public void setDiskSpaceService(DiskSpaceService diskSpaceService) {
+    this.diskSpaceService = diskSpaceService;
   }
 
   @GET
@@ -347,9 +361,10 @@ public class FilesResource {
   @ApiResponse(responseCode = "400", description = "Bad request")
   @ApiResponse(responseCode = "403", description = "Forbidden when destination folder is not writable")
   @ApiResponse(responseCode = "404", description = "Destination folder not found")
-  public Response uploadFile(@Context UriInfo uriInfo, @MultipartForm MultipartFormDataInput input)
+  public Response uploadFile(@Context UriInfo uriInfo, @MultipartForm MultipartFormDataInput input,
+                             @HeaderParam("Content-Length") @DefaultValue("-1") long contentLength)
       throws IOException {
-    return uploadFile("/", uriInfo, input);
+    return uploadFile("/", uriInfo, input, contentLength);
   }
 
   // The POST method is required here to be compatible with Html forms which do not support the PUT method.
@@ -364,8 +379,20 @@ public class FilesResource {
   @ApiResponse(responseCode = "400", description = "Bad request")
   @ApiResponse(responseCode = "403", description = "Forbidden when destination folder is not writable")
   @ApiResponse(responseCode = "404", description = "Destination folder not found")
+  @ApiResponse(responseCode = "507", description = "Not enough free disk space to store the file")
   public Response uploadFile(@PathParam("path") String path, @Context UriInfo uriInfo,
-                             @MultipartForm MultipartFormDataInput input) throws IOException {
+                             @MultipartForm MultipartFormDataInput input,
+                             @HeaderParam("Content-Length") @DefaultValue("-1") long contentLength)
+      throws IOException {
+
+    // The one write whose size is known before it happens. A sampler that runs once a minute cannot see a single 40 GB
+    // upload coming, so the announced length is checked against the volume the file system root is on.
+    try {
+      diskSpaceService.checkFileSystemWritable(contentLength);
+    } catch(InsufficientStorageException e) {
+      log.warn("Upload to {} refused: {}", path, e.getMessage());
+      return Response.status(INSUFFICIENT_STORAGE).entity(e.getMessage()).build();
+    }
 
     String folderPath = getPathOfFileToWrite(path);
     FileObject folder = resolveFileInFileSystem(folderPath);

--- a/opal-core-ws/src/main/java/org/obiba/opal/web/system/SystemResource.java
+++ b/opal-core-ws/src/main/java/org/obiba/opal/web/system/SystemResource.java
@@ -30,6 +30,9 @@ import org.obiba.opal.core.security.AuthConfigurationProvider;
 import org.obiba.opal.core.service.OpalGeneralConfigService;
 import org.obiba.opal.core.service.database.DatabaseRegistry;
 import org.obiba.opal.core.service.security.SystemKeyStoreService;
+import org.obiba.opal.core.service.storage.DiskLevel;
+import org.obiba.opal.core.service.storage.DiskSpaceService;
+import org.obiba.opal.core.service.storage.DiskStatus;
 import org.obiba.opal.web.model.Opal;
 import org.obiba.opal.web.security.KeyStoreResource;
 import org.obiba.opal.web.system.news.ObibaNews;
@@ -76,6 +79,9 @@ public class SystemResource {
 
   @Autowired
   private SystemKeyStoreService systemKeyStoreService;
+
+  @Autowired
+  private DiskSpaceService diskSpaceService;
 
   @Autowired
   private ApplicationContext applicationContext;
@@ -155,6 +161,11 @@ public class SystemResource {
       garbageCollectorUsagesValues.add(getGarbageCollector(GC));
     }
 
+    Collection<Opal.OpalStatus.DiskUsage> diskUsages = new ArrayList<>();
+    for (DiskStatus status : diskSpaceService.getStatuses()) {
+      diskUsages.add(getDiskUsage(status));
+    }
+
     return Opal.OpalStatus.newBuilder()//
         .setTimestamp(System.currentTimeMillis())//
         .setUptime(ManagementFactory.getRuntimeMXBean().getUptime())
@@ -162,6 +173,9 @@ public class SystemResource {
         .setNonHeapMemory(getMemory(ManagementFactory.getMemoryMXBean().getNonHeapMemoryUsage()))
         .setThreads(getThread(ManagementFactory.getThreadMXBean()))//
         .addAllGcs(garbageCollectorUsagesValues)//
+        .addAllDisks(diskUsages)//
+        .setDiskLevel(getDiskLevel(diskSpaceService.getLevel()))//
+        .setDiskEnforced(diskSpaceService.isEnforced())//
         .build();
   }
 
@@ -198,6 +212,20 @@ public class SystemResource {
         .setCount(threadMXBean.getThreadCount())//
         .setPeak(threadMXBean.getPeakThreadCount())//
         .build();
+  }
+
+  private Opal.OpalStatus.DiskUsage getDiskUsage(DiskStatus status) {
+    return Opal.OpalStatus.DiskUsage.newBuilder()//
+        .setName(status.getName())//
+        .setPath(status.getPath())//
+        .setTotal(status.getTotalSpace())//
+        .setUsable(status.getUsableSpace())//
+        .setLevel(getDiskLevel(status.getLevel()))//
+        .build();
+  }
+
+  private Opal.OpalStatus.DiskLevel getDiskLevel(DiskLevel level) {
+    return Opal.OpalStatus.DiskLevel.valueOf(level.name());
   }
 
   private Opal.OpalStatus.GarbageCollectorUsage getGarbageCollector(GarbageCollectorMXBean garbageCollectorMXBean) {

--- a/opal-core-ws/src/test/java/org/obiba/opal/web/FilesResourceTest.java
+++ b/opal-core-ws/src/test/java/org/obiba/opal/web/FilesResourceTest.java
@@ -19,6 +19,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.obiba.opal.core.runtime.OpalFileSystemService;
 import org.obiba.opal.core.service.security.SubjectAclService;
+import org.obiba.opal.core.service.storage.DiskSpaceService;
 import org.obiba.opal.fs.OpalFileSystem;
 import org.obiba.opal.fs.impl.DefaultOpalFileSystem;
 import org.obiba.opal.web.model.Opal.FileDto;
@@ -46,6 +47,8 @@ public class FilesResourceTest {
 
   private SubjectAclService subjectAclServiceMock;
 
+  private DiskSpaceService diskSpaceServiceMock;
+
   private OpalFileSystem fileSystem;
 
   private FilesResource filesResource;
@@ -65,6 +68,9 @@ public class FilesResourceTest {
   public void setUp() throws URISyntaxException {
     opalFileSystemServiceMock = createMock(OpalFileSystemService.class);
     subjectAclServiceMock = createMock(SubjectAclService.class);
+    // nice: the disk is not what these tests are about, and a nice mock lets every check through
+    diskSpaceServiceMock = createNiceMock(DiskSpaceService.class);
+    replay(diskSpaceServiceMock);
 
     String rootDir = getClass().getResource("/test-file-system").toURI().toString();
     File emptyDir = new File(rootDir.replace("file:", ""), "folder4/folder41");
@@ -75,6 +81,7 @@ public class FilesResourceTest {
     filesResource = new FilesResource();
     filesResource.setOpalFileSystemService(opalFileSystemServiceMock);
     filesResource.setSubjectAclService(subjectAclServiceMock);
+    filesResource.setDiskSpaceService(diskSpaceServiceMock);
 
     fileItemMock = createMock(InputPart.class);
     fileObjectMock = createMock(FileObject.class);
@@ -275,12 +282,13 @@ public class FilesResourceTest {
     };
     fileResource.setOpalFileSystemService(opalFileSystemServiceMock);
     fileResource.setSubjectAclService(subjectAclServiceMock);
+    fileResource.setDiskSpaceService(diskSpaceServiceMock);
 
     replay(opalFileSystemServiceMock, fileItemMock, uriInfoMock);
 
     // Upload the file.
     String destinationPath = "/folder1/folder11/folder111";
-    Response response = fileResource.uploadFile(destinationPath, uriInfoMock, null);
+    Response response = fileResource.uploadFile(destinationPath, uriInfoMock, null, -1);
     filesCreatedByTest.add(destinationPath);
 
     // Verify that the service response is CREATED.
@@ -309,8 +317,9 @@ public class FilesResourceTest {
     };
     fileResource.setOpalFileSystemService(opalFileSystemServiceMock);
     fileResource.setSubjectAclService(subjectAclServiceMock);
+    fileResource.setDiskSpaceService(diskSpaceServiceMock);
 
-    Response response = fileResource.uploadFile("/", uriInfoMock, null);
+    Response response = fileResource.uploadFile("/", uriInfoMock, null, -1);
     assertThat(response.getStatus()).isEqualTo(Status.BAD_REQUEST.getStatusCode());
 
     verify(opalFileSystemServiceMock);
@@ -329,14 +338,16 @@ public class FilesResourceTest {
       }
     };
     fileResource.setOpalFileSystemService(opalFileSystemServiceMock);
+    fileResource.setDiskSpaceService(diskSpaceServiceMock);
     filesResource.setSubjectAclService(subjectAclServiceMock);
+    filesResource.setDiskSpaceService(diskSpaceServiceMock);
 
     replay(opalFileSystemServiceMock, fileItemMock, uriInfoMock);
 
     // Upload the file.
     String destinationPath = "/folder1/folder11/folder111/patate";
     try {
-      fileResource.uploadFile(destinationPath, uriInfoMock, null);
+      fileResource.uploadFile(destinationPath, uriInfoMock, null, -1);
       assertThat(false).isTrue();
     } catch (NoSuchFileException e) {
 

--- a/opal-core/src/main/java/org/obiba/opal/core/runtime/jdbc/H2DatabaseUrls.java
+++ b/opal-core/src/main/java/org/obiba/opal/core/runtime/jdbc/H2DatabaseUrls.java
@@ -26,7 +26,8 @@ import java.util.regex.Pattern;
  * The name is the whole URL: H2 settings, which a {@code ;} would introduce, are not accepted. They are not a way of
  * tuning the connection but a second language, in which {@code INIT} alone runs arbitrary SQL — {@code RUNSCRIPT FROM}
  * a remote URL included — every time the connection is opened. The same setting can be passed as a connection
- * property, so {@link #validateProperties(String)} rejects it there too.
+ * property, so {@link #validateProperties(String)} rejects it there too, along with the two settings that would take
+ * away the fsync H2 performs when the database is closed.
  */
 public final class H2DatabaseUrls {
 
@@ -44,6 +45,20 @@ public final class H2DatabaseUrls {
    * H2 setting that runs SQL statements when a connection is opened.
    */
   private static final String INIT_SETTING = "INIT";
+
+  /**
+   * H2 setting that decides whether the JVM shutdown hook closes the database. Left at its default, it is one of the
+   * two ways the store is written to physical disk; turned off, the hook falls back to a checkpoint that flushes
+   * without forcing, and a power loss right after a clean stop can still lose the last writes.
+   */
+  private static final String DB_CLOSE_ON_EXIT_SETTING = "DB_CLOSE_ON_EXIT";
+
+  /**
+   * H2 setting that decides how long the database stays open after the last connection is closed. Left at 0, closing
+   * the connection pool is enough to close the database; anything else keeps it open past the point where Opal
+   * believes it has released it.
+   */
+  private static final String DB_CLOSE_DELAY_SETTING = "DB_CLOSE_DELAY";
 
   /**
    * H2 1.x page store file suffix, unreadable by the H2 2.x driver that Opal ships.
@@ -92,18 +107,33 @@ public final class H2DatabaseUrls {
 
   /**
    * Verify that the connection properties, a {@code ;} separated list of {@code name=value} pairs handed to the driver
-   * as they are, carry no {@code INIT} setting: H2 reads its settings from the properties as well as from the URL.
+   * as they are, carry none of the settings Opal reserves for itself: H2 reads its settings from the properties as
+   * well as from the URL, so the properties are the remaining way of expressing them.
+   * <p>
+   * {@code INIT} is refused because it runs arbitrary SQL. {@code DB_CLOSE_ON_EXIT} and {@code DB_CLOSE_DELAY} are
+   * refused because H2 only writes the store to physical disk when the database is closed — {@code FileStore.stop()}
+   * ends in a {@code FileChannel.force(true)} — and these are the two settings that stop that close from happening.
+   * Turning either off would silently take away the durability everything else assumes.
    *
-   * @throws InvalidH2DatabaseException if an INIT setting is present
+   * @throws InvalidH2DatabaseException if a reserved setting is present
    */
   public static void validateProperties(@Nullable String properties) {
     if(Strings.isNullOrEmpty(properties)) return;
     for(String property : properties.split(";")) {
       int idx = property.indexOf('=');
       String name = (idx < 0 ? property : property.substring(0, idx)).trim();
+      String value = idx < 0 ? "" : property.substring(idx + 1).trim();
       if(INIT_SETTING.equalsIgnoreCase(name)) {
         throw new InvalidH2DatabaseException(
             "The H2 INIT setting is not allowed: it runs SQL statements every time the connection is opened");
+      }
+      if(DB_CLOSE_ON_EXIT_SETTING.equalsIgnoreCase(name) && !"TRUE".equalsIgnoreCase(value)) {
+        throw new InvalidH2DatabaseException("The H2 " + DB_CLOSE_ON_EXIT_SETTING +
+            " setting cannot be turned off: the database would no longer be written to disk when the JVM stops");
+      }
+      if(DB_CLOSE_DELAY_SETTING.equalsIgnoreCase(name) && !"0".equals(value)) {
+        throw new InvalidH2DatabaseException("The H2 " + DB_CLOSE_DELAY_SETTING +
+            " setting cannot be changed: the database would stay open, and unwritten, after Opal has released it");
       }
     }
   }

--- a/opal-core/src/main/java/org/obiba/opal/core/runtime/storage/DefaultDiskSpaceService.java
+++ b/opal-core/src/main/java/org/obiba/opal/core/runtime/storage/DefaultDiskSpaceService.java
@@ -69,20 +69,11 @@ public class DefaultDiskSpaceService implements DiskSpaceService {
   @Value("${org.obiba.opal.storage.disk.enforce}")
   private boolean enforce;
 
-  @Value("${org.obiba.opal.storage.disk.warn.percent}")
-  private int warnPercent;
-
   @Value("${org.obiba.opal.storage.disk.warn.bytes}")
   private long warnBytes;
 
-  @Value("${org.obiba.opal.storage.disk.degraded.percent}")
-  private int degradedPercent;
-
   @Value("${org.obiba.opal.storage.disk.degraded.bytes}")
   private long degradedBytes;
-
-  @Value("${org.obiba.opal.storage.disk.critical.percent}")
-  private int criticalPercent;
 
   @Value("${org.obiba.opal.storage.disk.critical.bytes}")
   private long criticalBytes;
@@ -113,6 +104,11 @@ public class DefaultDiskSpaceService implements DiskSpaceService {
    * Paths that could not be measured, so that a volume Opal cannot see is reported once and not once a minute.
    */
   private final Set<String> unreadable = Collections.synchronizedSet(new HashSet<>());
+
+  /**
+   * Volumes too small to ever satisfy the thresholds, reported once each.
+   */
+  private final Set<String> oversizedThreshold = Collections.synchronizedSet(new HashSet<>());
 
   @Override
   public void start() {
@@ -177,14 +173,13 @@ public class DefaultDiskSpaceService implements DiskSpaceService {
     if(volume == null || volume.status.getLevel() == DiskLevel.UNKNOWN) return;
 
     long needed = withSafetyMargin(requiredBytes);
-    // What the write must leave behind it, and not only what it takes: the floor is what lets the databases compact
-    // and close cleanly, so a write is refused when it would eat into the floor rather than when it runs out.
-    long floor = requiredFreeSpace(volume.status.getTotalSpace(), degradedPercent, degradedBytes);
-    if(volume.status.getUsableSpace() - needed >= floor) return;
+    // What the write must leave behind it, and not only what it takes: the DEGRADED floor is what lets the databases
+    // compact and close cleanly, so a write is refused when it would eat into the floor rather than when it runs out.
+    if(volume.status.getUsableSpace() - needed >= degradedBytes) return;
 
     throw new InsufficientStorageException(
         "Not enough free disk space on " + volume.status.getPath() + " to write " + needed + " bytes: " +
-            volume.status.getUsableSpace() + " bytes free, of which " + floor + " are reserved.");
+            volume.status.getUsableSpace() + " bytes free, of which " + degradedBytes + " are reserved.");
   }
 
   @Override
@@ -221,6 +216,7 @@ public class DefaultDiskSpaceService implements DiskSpaceService {
       DiskLevel previous = level;
       volumes = sampled;
       level = worst;
+      checkThresholdsFit(sampled);
       report(previous, worst);
     } catch(RuntimeException e) {
       // The checker is a safety net, and a safety net that throws on the scheduler thread stops being one.
@@ -243,6 +239,25 @@ public class DefaultDiskSpaceService implements DiskSpaceService {
       log.info("Free disk space is back to normal: {}", detail);
     }
     eventBus.post(new DiskLevelChangedEvent(previous, current, detail));
+  }
+
+  /**
+   * A threshold larger than the volume it applies to holds that level on however empty the volume is. That is a
+   * configuration error rather than a reading worth acting upon, and saying so once is more use to an administrator
+   * than silently clamping the threshold to something they did not ask for. Only the WARN threshold is checked, being
+   * the largest of the three. Done here rather than at start(), since the volumes are resolved on every sample and
+   * the Opal file system root only appears once the configuration has been read.
+   */
+  private void checkThresholdsFit(List<Volume> sampled) {
+    for(Volume volume : sampled) {
+      DiskStatus status = volume.status;
+      if(status.getTotalSpace() <= 0 || status.getTotalSpace() > warnBytes) continue;
+      if(oversizedThreshold.add(status.getPath())) {
+        log.warn("Volume {} ({}) holds {} bytes in total, less than the {} bytes of the WARN threshold: it can never " +
+                "report OK. Lower org.obiba.opal.storage.disk.warn.bytes, or give Opal a larger volume.",
+            status.getName(), status.getPath(), status.getTotalSpace(), warnBytes);
+      }
+    }
   }
 
   private String describeWorstVolume() {
@@ -335,21 +350,18 @@ public class DefaultDiskSpaceService implements DiskSpaceService {
     return null;
   }
 
+  /**
+   * The thresholds are absolute sizes and deliberately not a share of the volume. A level answers whether there is
+   * room left for Opal to do its work, and what has to fit — an import, a compaction, a clean close — does not need
+   * more room on a larger disk. A percentage gets the answer more wrong the bigger the volume gets: 15% of a 468 GB
+   * volume asks for 70 GB of headroom that nothing is ever going to use.
+   */
   DiskLevel levelOf(long total, long usable) {
     if(total <= 0 || usable < 0) return DiskLevel.UNKNOWN;
-    if(usable < requiredFreeSpace(total, criticalPercent, criticalBytes)) return DiskLevel.CRITICAL;
-    if(usable < requiredFreeSpace(total, degradedPercent, degradedBytes)) return DiskLevel.DEGRADED;
-    if(usable < requiredFreeSpace(total, warnPercent, warnBytes)) return DiskLevel.WARN;
+    if(usable < criticalBytes) return DiskLevel.CRITICAL;
+    if(usable < degradedBytes) return DiskLevel.DEGRADED;
+    if(usable < warnBytes) return DiskLevel.WARN;
     return DiskLevel.OK;
-  }
-
-  /**
-   * A percentage and an absolute size, whichever is larger. Neither works alone: 5% of a 10 TB volume is 500 GB, which
-   * would keep a mostly empty server permanently degraded, and 5% of a 20 GB volume is 1 GB, which a single import can
-   * cross without warning.
-   */
-  long requiredFreeSpace(long total, int percent, long bytes) {
-    return Math.max(total / 100 * percent, bytes);
   }
 
   //

--- a/opal-core/src/main/java/org/obiba/opal/core/runtime/storage/DefaultDiskSpaceService.java
+++ b/opal-core/src/main/java/org/obiba/opal/core/runtime/storage/DefaultDiskSpaceService.java
@@ -239,7 +239,7 @@ public class DefaultDiskSpaceService implements DiskSpaceService {
           enforce ? "Imports, copies, backups and uploads are being refused." : "Enforcement is off, nothing is refused.");
     } else if(current == DiskLevel.WARN) {
       log.warn("Free disk space is low: {}", detail);
-    } else if(previous.isAtLeast(DiskLevel.WARN)) {
+    } else if(current == DiskLevel.OK && previous.isAtLeast(DiskLevel.WARN)) {
       log.info("Free disk space is back to normal: {}", detail);
     }
     eventBus.post(new DiskLevelChangedEvent(previous, current, detail));

--- a/opal-core/src/main/java/org/obiba/opal/core/runtime/storage/DefaultDiskSpaceService.java
+++ b/opal-core/src/main/java/org/obiba/opal/core/runtime/storage/DefaultDiskSpaceService.java
@@ -1,0 +1,399 @@
+/*
+ * Copyright (c) 2026 OBiBa. All rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.obiba.opal.core.runtime.storage;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.eventbus.EventBus;
+import jakarta.annotation.Nullable;
+import org.obiba.opal.core.cfg.OpalConfigurationService;
+import org.obiba.opal.core.event.DiskLevelChangedEvent;
+import org.obiba.opal.core.service.storage.DiskLevel;
+import org.obiba.opal.core.service.storage.DiskSpaceService;
+import org.obiba.opal.core.service.storage.DiskStatus;
+import org.obiba.opal.core.service.storage.InsufficientStorageException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.ScheduledFuture;
+
+/**
+ * Samples the free space of the volumes Opal writes to, on a timer, and answers from the last sample.
+ * <p>
+ * Reading is cheap but not free, and the callers that ask are on request threads: the {@code stat} calls happen on the
+ * sampler thread and everything else reads a volatile field.
+ * <p>
+ * The folders are resolved on every sample rather than once at startup. Several of them do not exist on a fresh
+ * installation, the Opal file system root is only known once the configuration has been read, and a volume can be
+ * mounted under a running server. When a folder is missing, the nearest existing ancestor is measured instead: that is
+ * the volume the folder would be created on.
+ */
+@Component
+public class DefaultDiskSpaceService implements DiskSpaceService {
+
+  private static final Logger log = LoggerFactory.getLogger(DefaultDiskSpaceService.class);
+
+  @Value("${OPAL_HOME}/data")
+  private File dataFolder;
+
+  @Value("${OPAL_HOME}/data/config")
+  private File configFolder;
+
+  @Value("${OPAL_HOME}/data/h2")
+  private File h2Root;
+
+  @Value("${OPAL_HOME}/logs")
+  private File logsFolder;
+
+  @Value("${org.obiba.opal.storage.disk.interval}")
+  private long interval;
+
+  @Value("${org.obiba.opal.storage.disk.enforce}")
+  private boolean enforce;
+
+  @Value("${org.obiba.opal.storage.disk.warn.percent}")
+  private int warnPercent;
+
+  @Value("${org.obiba.opal.storage.disk.warn.bytes}")
+  private long warnBytes;
+
+  @Value("${org.obiba.opal.storage.disk.degraded.percent}")
+  private int degradedPercent;
+
+  @Value("${org.obiba.opal.storage.disk.degraded.bytes}")
+  private long degradedBytes;
+
+  @Value("${org.obiba.opal.storage.disk.critical.percent}")
+  private int criticalPercent;
+
+  @Value("${org.obiba.opal.storage.disk.critical.bytes}")
+  private long criticalBytes;
+
+  /**
+   * How much more room than the announced size a write is asked to leave. An upload is written through a temporary
+   * file and a multipart envelope is bigger than its payload, so the announced length is a lower bound.
+   */
+  @Value("${org.obiba.opal.storage.disk.upload.safetyFactor}")
+  private double safetyFactor;
+
+  @Autowired
+  private OpalConfigurationService opalConfigurationService;
+
+  @Autowired
+  private StorageTaskScheduler scheduler;
+
+  @Autowired
+  private EventBus eventBus;
+
+  private volatile List<Volume> volumes = ImmutableList.of();
+
+  private volatile DiskLevel level = DiskLevel.UNKNOWN;
+
+  private ScheduledFuture<?> sampler;
+
+  /**
+   * Paths that could not be measured, so that a volume Opal cannot see is reported once and not once a minute.
+   */
+  private final Set<String> unreadable = Collections.synchronizedSet(new HashSet<>());
+
+  @Override
+  public void start() {
+    sample();
+    if(interval <= 0) {
+      log.info("Disk space monitoring is disabled (org.obiba.opal.storage.disk.interval={})", interval);
+      return;
+    }
+    sampler = scheduler.scheduleWithFixedDelay(this::sample, Duration.ofMillis(interval));
+    log.info("Disk space monitoring every {} ms, enforcement is {}", interval, enforce ? "on" : "off");
+  }
+
+  @Override
+  public void stop() {
+    if(sampler != null) {
+      sampler.cancel(false);
+      sampler = null;
+    }
+  }
+
+  @Override
+  public DiskLevel getLevel() {
+    return level;
+  }
+
+  @Override
+  public List<DiskStatus> getStatuses() {
+    ImmutableList.Builder<DiskStatus> builder = ImmutableList.builder();
+    for(Volume volume : volumes) {
+      builder.add(volume.status);
+    }
+    return builder.build();
+  }
+
+  @Nullable
+  @Override
+  public DiskStatus getStatus(File path) {
+    Volume volume = findVolume(path);
+    return volume == null ? null : volume.status;
+  }
+
+  @Override
+  public boolean isEnforced() {
+    return enforce;
+  }
+
+  @Override
+  public void checkWritable() throws InsufficientStorageException {
+    DiskLevel current = level;
+    if(!enforce || !current.isAtLeast(DiskLevel.DEGRADED)) return;
+    throw new InsufficientStorageException(
+        "Not enough free disk space to start this operation: " + describeWorstVolume() +
+            ". Free some space, or remove data that is no longer needed, and try again.");
+  }
+
+  @Override
+  public void checkWritable(File path, long requiredBytes) throws InsufficientStorageException {
+    if(!enforce) return;
+    checkWritable();
+
+    Volume volume = findVolume(path);
+    if(volume == null || volume.status.getLevel() == DiskLevel.UNKNOWN) return;
+
+    long needed = withSafetyMargin(requiredBytes);
+    // What the write must leave behind it, and not only what it takes: the floor is what lets the databases compact
+    // and close cleanly, so a write is refused when it would eat into the floor rather than when it runs out.
+    long floor = requiredFreeSpace(volume.status.getTotalSpace(), degradedPercent, degradedBytes);
+    if(volume.status.getUsableSpace() - needed >= floor) return;
+
+    throw new InsufficientStorageException(
+        "Not enough free disk space on " + volume.status.getPath() + " to write " + needed + " bytes: " +
+            volume.status.getUsableSpace() + " bytes free, of which " + floor + " are reserved.");
+  }
+
+  @Override
+  public void checkFileSystemWritable(long requiredBytes) throws InsufficientStorageException {
+    File root = fileSystemRoot();
+    if(root == null) {
+      checkWritable();
+      return;
+    }
+    checkWritable(root, requiredBytes);
+  }
+
+  //
+  // Private methods
+  //
+
+  private long withSafetyMargin(long requiredBytes) {
+    if(requiredBytes <= 0) return 0;
+    double margin = safetyFactor < 1 ? 1 : safetyFactor;
+    double needed = requiredBytes * margin;
+    return needed >= Long.MAX_VALUE ? Long.MAX_VALUE : (long) needed;
+  }
+
+  /**
+   * Take one reading of every watched volume and publish it as a whole, so that a caller never sees half of a sample.
+   */
+  private void sample() {
+    try {
+      List<Volume> sampled = readVolumes();
+      DiskLevel worst = DiskLevel.UNKNOWN;
+      for(Volume volume : sampled) {
+        worst = worst.worst(volume.status.getLevel());
+      }
+      DiskLevel previous = level;
+      volumes = sampled;
+      level = worst;
+      report(previous, worst);
+    } catch(RuntimeException e) {
+      // The checker is a safety net, and a safety net that throws on the scheduler thread stops being one.
+      log.warn("Disk space sampling failed: {}", e.getMessage());
+    }
+  }
+
+  /**
+   * Log a transition, not a state. A full disk stays full, and a level triggered message would say so every minute.
+   */
+  private void report(DiskLevel previous, DiskLevel current) {
+    if(previous == current) return;
+    String detail = describeWorstVolume();
+    if(current.isAtLeast(DiskLevel.DEGRADED)) {
+      log.error("Free disk space is {}: {}. {}", current, detail,
+          enforce ? "Imports, copies, backups and uploads are being refused." : "Enforcement is off, nothing is refused.");
+    } else if(current == DiskLevel.WARN) {
+      log.warn("Free disk space is low: {}", detail);
+    } else if(previous.isAtLeast(DiskLevel.WARN)) {
+      log.info("Free disk space is back to normal: {}", detail);
+    }
+    eventBus.post(new DiskLevelChangedEvent(previous, current, detail));
+  }
+
+  private String describeWorstVolume() {
+    Volume worst = null;
+    for(Volume volume : volumes) {
+      if(worst == null || volume.status.getLevel().isWorseThan(worst.status.getLevel())) {
+        worst = volume;
+      }
+    }
+    return worst == null ? "no volume could be measured" : worst.status.toString();
+  }
+
+  private List<Volume> readVolumes() {
+    // Registration order decides which folder names a volume: the folders that hold data first, since that is the one
+    // an administrator needs to see. Folders that share a mount, which is the usual case, are collapsed into one.
+    Map<String, File> watched = new LinkedHashMap<>();
+    watched.put("data", dataFolder);
+    watched.put("config", configFolder);
+    watched.put("h2", h2Root);
+    File root = fileSystemRoot();
+    if(root != null) watched.put("filesystem", root);
+    watched.put("logs", logsFolder);
+    watched.put("tmp", new File(System.getProperty("java.io.tmpdir")));
+
+    Map<FileStore, Sample> byStore = new LinkedHashMap<>();
+    for(Map.Entry<String, File> entry : watched.entrySet()) {
+      Path path = nearestExisting(entry.getValue());
+      if(path == null) continue;
+      try {
+        FileStore store = Files.getFileStore(path);
+        Sample sample = byStore.get(store);
+        if(sample == null) {
+          byStore.put(store, new Sample(entry.getKey(), path, store));
+        } else {
+          sample.names.add(entry.getKey());
+        }
+        unreadable.remove(entry.getValue().getAbsolutePath());
+      } catch(IOException | RuntimeException e) {
+        logUnreadable(entry.getValue(), e);
+      }
+    }
+
+    ImmutableList.Builder<Volume> builder = ImmutableList.builder();
+    for(Sample sample : byStore.values()) {
+      builder.add(sample.toVolume());
+    }
+    return builder.build();
+  }
+
+  private void logUnreadable(File file, Exception e) {
+    if(unreadable.add(file.getAbsolutePath())) {
+      log.warn("Cannot read the free disk space of {}: {}", file.getAbsolutePath(), e.getMessage());
+    }
+  }
+
+  /**
+   * The volume a folder is on, whether or not the folder itself is there yet.
+   */
+  @Nullable
+  private Path nearestExisting(@Nullable File file) {
+    for(File current = file; current != null; current = current.getParentFile()) {
+      if(current.exists()) return current.toPath();
+    }
+    return null;
+  }
+
+  @Nullable
+  private File fileSystemRoot() {
+    try {
+      String root = opalConfigurationService.getOpalConfiguration().getFileSystemRoot();
+      return Strings.isNullOrEmpty(root) ? null : new File(root);
+    } catch(RuntimeException e) {
+      // Not yet readable on a first startup, and it will be on the next sample.
+      return null;
+    }
+  }
+
+  @Nullable
+  private Volume findVolume(@Nullable File path) {
+    Path existing = nearestExisting(path);
+    if(existing == null) return null;
+    try {
+      FileStore store = Files.getFileStore(existing);
+      for(Volume volume : volumes) {
+        if(store.equals(volume.store)) return volume;
+      }
+    } catch(IOException | RuntimeException e) {
+      logUnreadable(path, e);
+    }
+    return null;
+  }
+
+  DiskLevel levelOf(long total, long usable) {
+    if(total <= 0 || usable < 0) return DiskLevel.UNKNOWN;
+    if(usable < requiredFreeSpace(total, criticalPercent, criticalBytes)) return DiskLevel.CRITICAL;
+    if(usable < requiredFreeSpace(total, degradedPercent, degradedBytes)) return DiskLevel.DEGRADED;
+    if(usable < requiredFreeSpace(total, warnPercent, warnBytes)) return DiskLevel.WARN;
+    return DiskLevel.OK;
+  }
+
+  /**
+   * A percentage and an absolute size, whichever is larger. Neither works alone: 5% of a 10 TB volume is 500 GB, which
+   * would keep a mostly empty server permanently degraded, and 5% of a 20 GB volume is 1 GB, which a single import can
+   * cross without warning.
+   */
+  long requiredFreeSpace(long total, int percent, long bytes) {
+    return Math.max(total / 100 * percent, bytes);
+  }
+
+  //
+  // Inner classes
+  //
+
+  private class Sample {
+
+    private final List<String> names = new ArrayList<>();
+
+    private final Path path;
+
+    private final FileStore store;
+
+    private Sample(String name, Path path, FileStore store) {
+      this.names.add(name);
+      this.path = path;
+      this.store = store;
+    }
+
+    private Volume toVolume() {
+      long total = -1;
+      long usable = -1;
+      try {
+        total = store.getTotalSpace();
+        usable = store.getUsableSpace();
+      } catch(IOException | RuntimeException e) {
+        logUnreadable(path.toFile(), e);
+      }
+      DiskStatus status = new DiskStatus(Joiner.on(", ").join(names), path.toAbsolutePath().toString(), total, usable,
+          levelOf(total, usable));
+      return new Volume(store, status);
+    }
+  }
+
+  private static class Volume {
+
+    private final FileStore store;
+
+    private final DiskStatus status;
+
+    private Volume(FileStore store, DiskStatus status) {
+      this.store = store;
+      this.status = status;
+    }
+  }
+}

--- a/opal-core/src/main/java/org/obiba/opal/core/runtime/storage/H2Checkpointer.java
+++ b/opal-core/src/main/java/org/obiba/opal/core/runtime/storage/H2Checkpointer.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026 OBiBa. All rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.obiba.opal.core.runtime.storage;
+
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.obiba.opal.core.service.SystemService;
+import org.obiba.opal.core.service.database.DatabaseRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ScheduledFuture;
+
+/**
+ * Forces the open H2 databases to physical disk, periodically.
+ * <p>
+ * Nothing else does. While Opal runs, {@code FileStore.writeInBackground()} only calls {@code MVStore.tryCommit()}:
+ * pages are written to the file, and the file is never synced. {@code WRITE_DELAY} sets how often that commit happens
+ * and buys no durability at all. A machine that loses power has lost everything written since the last sync, and
+ * without this task the last sync was the last time the database was opened.
+ * <p>
+ * The shutdown case is not this task's business and is deliberately not implemented here. H2 already ends a clean
+ * close in {@code FileChannel.force(true)} — {@code closeOpenFilesAndUnlock()} → {@code FileStore.stop()} →
+ * {@code writeCleanShutdown()} → {@code sync()} — and that close is reached both when the last connection is released
+ * and from the JVM shutdown hook. Adding a checkpoint there would add code that does nothing;
+ * {@code H2DatabaseUrls.validateProperties} is what keeps the settings that would disable it out of reach.
+ */
+@Component
+public class H2Checkpointer implements SystemService {
+
+  private static final Logger log = LoggerFactory.getLogger(H2Checkpointer.class);
+
+  /**
+   * Flush the store and fsync the file. {@code CHECKPOINT} alone does not sync, which is the whole point here.
+   */
+  private static final String CHECKPOINT_SYNC = "CHECKPOINT SYNC";
+
+  @Value("${org.obiba.opal.storage.checkpoint.interval}")
+  private long interval;
+
+  @Autowired
+  @Qualifier("configDataSource")
+  private DataSource configDataSource;
+
+  @Autowired
+  private DatabaseRegistry databaseRegistry;
+
+  @Autowired
+  private StorageTaskScheduler scheduler;
+
+  private ScheduledFuture<?> task;
+
+  /**
+   * Data sources whose checkpoint failed, so that a database Opal is not administrator of is reported once rather than
+   * on every tick.
+   */
+  private final Set<String> failed = Collections.synchronizedSet(new HashSet<>());
+
+  @Override
+  public void start() {
+    if(interval <= 0) {
+      log.info("H2 checkpointing is disabled (org.obiba.opal.storage.checkpoint.interval={})", interval);
+      return;
+    }
+    task = scheduler.scheduleWithFixedDelay(this::checkpoint, Duration.ofMillis(interval));
+    log.info("H2 checkpointing every {} ms", interval);
+  }
+
+  @Override
+  public void stop() {
+    if(task != null) {
+      task.cancel(false);
+      task = null;
+    }
+  }
+
+  /**
+   * The configuration database, plus the storage databases that are open. Databases that have never been used are not
+   * opened to be checkpointed.
+   */
+  void checkpoint() {
+    checkpoint(configDataSource);
+    for(DataSource dataSource : databaseRegistry.getLoadedDataSources()) {
+      checkpoint(dataSource);
+    }
+  }
+
+  private void checkpoint(DataSource dataSource) {
+    if(dataSource == null || isBusy(dataSource)) return;
+    try(Connection connection = dataSource.getConnection()) {
+      if(!isH2(connection)) return;
+      long start = System.currentTimeMillis();
+      try(Statement statement = connection.createStatement()) {
+        statement.execute(CHECKPOINT_SYNC);
+      }
+      failed.remove(key(dataSource));
+      log.debug("Checkpointed {} in {} ms", connection.getMetaData().getURL(), System.currentTimeMillis() - start);
+    } catch(SQLException | RuntimeException e) {
+      // CHECKPOINT SYNC needs the admin right. Opal creates the databases it registers, so it holds that right; an
+      // externally created H2 database opened with a restricted account is the case this catches.
+      if(failed.add(key(dataSource))) {
+        log.warn("Cannot checkpoint an H2 database, its writes stay unsynced until it is closed: {}", e.getMessage());
+      }
+    }
+  }
+
+  /**
+   * The pools are built with no maximum wait, so borrowing a connection from a saturated one would block this thread
+   * for as long as the load lasts. A database that busy is being written to, which is the case a checkpoint matters
+   * least for: skip it and take it on the next tick.
+   */
+  private boolean isBusy(DataSource dataSource) {
+    if(!(dataSource instanceof BasicDataSource)) return false;
+    BasicDataSource pool = (BasicDataSource) dataSource;
+    boolean busy = pool.getNumIdle() == 0 && pool.getNumActive() >= pool.getMaxTotal();
+    if(busy) log.debug("Skipping the checkpoint of {}, its connection pool is saturated", pool.getUrl());
+    return busy;
+  }
+
+  /**
+   * Ask the connection rather than the registered driver class: the configuration database can be an external
+   * PostgreSQL one, which manages its own durability and has no CHECKPOINT statement to run.
+   */
+  private boolean isH2(Connection connection) throws SQLException {
+    return "H2".equalsIgnoreCase(connection.getMetaData().getDatabaseProductName());
+  }
+
+  private String key(DataSource dataSource) {
+    return dataSource.getClass().getName() + '@' + System.identityHashCode(dataSource);
+  }
+}

--- a/opal-core/src/main/java/org/obiba/opal/core/runtime/storage/StorageTaskScheduler.java
+++ b/opal-core/src/main/java/org/obiba/opal/core/runtime/storage/StorageTaskScheduler.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 OBiBa. All rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.obiba.opal.core.runtime.storage;
+
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.concurrent.ScheduledFuture;
+
+/**
+ * The timer the storage services run on: the disk space sampler and the H2 checkpointer.
+ * <p>
+ * They get their own threads rather than the ones behind {@code @Scheduled}, which are a single thread shared by every
+ * annotated method in Opal. A {@code CHECKPOINT SYNC} on a large store is an fsync of everything written since the last
+ * one, and while it runs nothing else on that thread moves — including the R session cleanup that expects to run every
+ * minute.
+ * <p>
+ * This is deliberately not a {@code TaskScheduler} bean. Declaring one would make it the scheduler for every
+ * {@code @Scheduled} method in the application, which is the opposite of the isolation wanted here.
+ */
+@Component
+public class StorageTaskScheduler implements InitializingBean, DisposableBean {
+
+  private static final int POOL_SIZE = 2;
+
+  private final ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+
+  @Override
+  public void afterPropertiesSet() {
+    scheduler.setPoolSize(POOL_SIZE);
+    scheduler.setThreadNamePrefix("opal-storage-");
+    // A checkpoint in flight is not worth waiting for at shutdown: the close that follows performs the same fsync.
+    scheduler.setWaitForTasksToCompleteOnShutdown(false);
+    scheduler.setAwaitTerminationSeconds(5);
+    scheduler.initialize();
+  }
+
+  @Override
+  public void destroy() {
+    scheduler.shutdown();
+  }
+
+  /**
+   * Run a task repeatedly, waiting the given delay between the end of one run and the start of the next. A run that
+   * takes longer than the delay therefore pushes the next one back instead of piling up behind it.
+   */
+  public ScheduledFuture<?> scheduleWithFixedDelay(Runnable task, Duration delay) {
+    return scheduler.scheduleWithFixedDelay(task, delay);
+  }
+}

--- a/opal-core/src/main/java/org/obiba/opal/core/service/DefaultDatabaseRegistry.java
+++ b/opal-core/src/main/java/org/obiba/opal/core/service/DefaultDatabaseRegistry.java
@@ -141,6 +141,13 @@ public class DefaultDatabaseRegistry implements DatabaseRegistry {
   }
 
   @Override
+  public Iterable<DataSource> getLoadedDataSources() {
+    // asMap() is a view of what the cache holds, and reading it does not go through the CacheLoader: a database that
+    // has never been used stays closed.
+    return ImmutableList.copyOf(dataSourceCache.asMap().values());
+  }
+
+  @Override
   public void create(@NotNull Database database)
       throws ConstraintViolationException, MultipleIdentifiersDatabaseException {
     if(databaseRepository.findByName(database.getName()).isEmpty()) {

--- a/opal-core/src/main/resources/META-INF/defaults.properties
+++ b/opal-core/src/main/resources/META-INF/defaults.properties
@@ -63,6 +63,32 @@ org.obiba.magma.readDataPointsCount=100000
 # JDBC
 org.obiba.opal.jdbc.maxPoolSize=300
 
+# Storage safeguards
+# How often the open H2 databases are forced to physical disk, in milliseconds. Nothing else does it while Opal runs:
+# H2 writes pages in the background but never syncs the file, so a power loss costs everything written since the last
+# checkpoint. Set to 0 or less to disable.
+org.obiba.opal.storage.checkpoint.interval=300000
+# How often the free space of the volumes Opal writes to is sampled, in milliseconds. Set to 0 or less to disable.
+org.obiba.opal.storage.disk.interval=60000
+# Whether the levels below are acted upon. When false the readings are still taken and reported in /system/status, and
+# nothing is refused: the thresholds can be observed against a real deployment before they start failing jobs.
+org.obiba.opal.storage.disk.enforce=false
+# Each level is reached when the free space falls under the larger of the percentage and the number of bytes. Neither
+# works alone: 5% of a 10 TB volume is 500 GB, and 5% of a 20 GB volume is 1 GB.
+# WARN: reported, nothing is refused.
+org.obiba.opal.storage.disk.warn.percent=15
+org.obiba.opal.storage.disk.warn.bytes=5368709120
+# DEGRADED: imports, copies, backups, restores and uploads are refused. Reads, login and configuration writes keep
+# working, which is what leaves a way in to make room.
+org.obiba.opal.storage.disk.degraded.percent=5
+org.obiba.opal.storage.disk.degraded.bytes=1073741824
+# CRITICAL: running tasks are cancelled too. A cancelled import can be run again; a database that hits a full disk
+# closes itself without persisting and costs a restart.
+org.obiba.opal.storage.disk.critical.percent=1
+org.obiba.opal.storage.disk.critical.bytes=268435456
+# How much more room than its announced size an upload is asked to leave.
+org.obiba.opal.storage.disk.upload.safetyFactor=1.2
+
 # Configuration database
 # Empty means the embedded H2 database in ${OPAL_HOME}/data/config, opened as user 'opal' with the
 # <databasePassword> that Opal generates in ${OPAL_HOME}/data/opal-config.xml.

--- a/opal-core/src/main/resources/META-INF/defaults.properties
+++ b/opal-core/src/main/resources/META-INF/defaults.properties
@@ -73,19 +73,17 @@ org.obiba.opal.storage.disk.interval=60000
 # Whether the levels below are acted upon. When false the readings are still taken and reported in /system/status, and
 # nothing is refused: the thresholds can be observed against a real deployment before they start failing jobs.
 org.obiba.opal.storage.disk.enforce=false
-# Each level is reached when the free space falls under the larger of the percentage and the number of bytes. Neither
-# works alone: 5% of a 10 TB volume is 500 GB, and 5% of a 20 GB volume is 1 GB.
+# Each level is reached when the free space falls under the number of bytes. The thresholds are absolute and not a
+# share of the volume: what has to fit is an import, a compaction or a clean close, and none of those needs more room
+# on a larger disk. A deployment whose imports are much bigger than usual raises warn.bytes.
 # WARN: reported, nothing is refused.
-org.obiba.opal.storage.disk.warn.percent=15
 org.obiba.opal.storage.disk.warn.bytes=5368709120
 # DEGRADED: imports, copies, backups, restores and uploads are refused. Reads, login and configuration writes keep
 # working, which is what leaves a way in to make room.
-org.obiba.opal.storage.disk.degraded.percent=5
-org.obiba.opal.storage.disk.degraded.bytes=1073741824
+org.obiba.opal.storage.disk.degraded.bytes=2147483648
 # CRITICAL: running tasks are cancelled too. A cancelled import can be run again; a database that hits a full disk
 # closes itself without persisting and costs a restart.
-org.obiba.opal.storage.disk.critical.percent=1
-org.obiba.opal.storage.disk.critical.bytes=268435456
+org.obiba.opal.storage.disk.critical.bytes=536870912
 # How much more room than its announced size an upload is asked to leave.
 org.obiba.opal.storage.disk.upload.safetyFactor=1.2
 

--- a/opal-core/src/test/java/org/obiba/opal/core/runtime/jdbc/H2DatabaseUrlsTest.java
+++ b/opal-core/src/test/java/org/obiba/opal/core/runtime/jdbc/H2DatabaseUrlsTest.java
@@ -65,10 +65,23 @@ public class H2DatabaseUrlsTest {
   }
 
   @Test
-  public void test_properties_without_an_init_setting_are_accepted() {
+  public void test_close_connection_properties_are_rejected() {
+    // H2 writes the store to physical disk when the database is closed, and these are the two ways of preventing
+    // that close from happening
+    assertPropertiesRejected("DB_CLOSE_ON_EXIT=FALSE");
+    assertPropertiesRejected("MODE=PostgreSQL;db_close_on_exit=false");
+    assertPropertiesRejected("DB_CLOSE_ON_EXIT");
+    assertPropertiesRejected("DB_CLOSE_DELAY=-1");
+    assertPropertiesRejected(" DB_CLOSE_DELAY = 10 ");
+  }
+
+  @Test
+  public void test_properties_without_a_reserved_setting_are_accepted() {
     H2DatabaseUrls.validateProperties(null);
     H2DatabaseUrls.validateProperties("");
-    H2DatabaseUrls.validateProperties("MODE=PostgreSQL;DB_CLOSE_DELAY=-1");
+    H2DatabaseUrls.validateProperties("MODE=PostgreSQL");
+    // stating the defaults Opal relies on is not a change
+    H2DatabaseUrls.validateProperties("DB_CLOSE_ON_EXIT=TRUE;DB_CLOSE_DELAY=0");
     // a value that merely mentions the setting is not one
     H2DatabaseUrls.validateProperties("MODE=INIT");
   }

--- a/opal-core/src/test/java/org/obiba/opal/core/runtime/storage/DefaultDiskSpaceServiceTest.java
+++ b/opal-core/src/test/java/org/obiba/opal/core/runtime/storage/DefaultDiskSpaceServiceTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 OBiBa. All rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.obiba.opal.core.runtime.storage;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.obiba.opal.core.service.storage.DiskLevel;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+public class DefaultDiskSpaceServiceTest {
+
+  private static final long GIB = 1024L * 1024 * 1024;
+
+  private DefaultDiskSpaceService service;
+
+  @Before
+  public void setUp() {
+    service = new DefaultDiskSpaceService();
+    // the shipped defaults, so that the test says what an installation actually does
+    ReflectionTestUtils.setField(service, "warnPercent", 15);
+    ReflectionTestUtils.setField(service, "warnBytes", 5 * GIB);
+    ReflectionTestUtils.setField(service, "degradedPercent", 5);
+    ReflectionTestUtils.setField(service, "degradedBytes", GIB);
+    ReflectionTestUtils.setField(service, "criticalPercent", 1);
+    ReflectionTestUtils.setField(service, "criticalBytes", 256 * 1024 * 1024L);
+  }
+
+  @Test
+  public void test_a_percentage_and_a_size_whichever_is_larger() {
+    // on a small volume the percentage is meaningless and the absolute floor decides
+    assertThat(service.requiredFreeSpace(20 * GIB, 5, GIB)).isEqualTo(GIB);
+    // on a large one it is the other way round
+    assertThat(service.requiredFreeSpace(1000 * GIB, 5, GIB)).isEqualTo(50 * GIB);
+  }
+
+  @Test
+  public void test_levels_on_a_small_volume() {
+    long total = 20 * GIB;
+    assertThat(service.levelOf(total, 10 * GIB)).isEqualTo(DiskLevel.OK);
+    // 15% of 20 GiB is 3 GiB, but the 5 GiB floor is larger
+    assertThat(service.levelOf(total, 4 * GIB)).isEqualTo(DiskLevel.WARN);
+    assertThat(service.levelOf(total, 900 * 1024 * 1024L)).isEqualTo(DiskLevel.DEGRADED);
+    assertThat(service.levelOf(total, 100 * 1024 * 1024L)).isEqualTo(DiskLevel.CRITICAL);
+  }
+
+  @Test
+  public void test_levels_on_a_large_volume() {
+    long total = 10000 * GIB;
+    assertThat(service.levelOf(total, 2000 * GIB)).isEqualTo(DiskLevel.OK);
+    // there the percentages are what decide: 15%, 5% and 1% of 10 TiB
+    assertThat(service.levelOf(total, 1000 * GIB)).isEqualTo(DiskLevel.WARN);
+    assertThat(service.levelOf(total, 300 * GIB)).isEqualTo(DiskLevel.DEGRADED);
+    assertThat(service.levelOf(total, 50 * GIB)).isEqualTo(DiskLevel.CRITICAL);
+  }
+
+  @Test
+  public void test_a_volume_that_could_not_be_read_is_unknown() {
+    // and UNKNOWN blocks nothing, so a broken reading is not an outage
+    assertThat(service.levelOf(-1, -1)).isEqualTo(DiskLevel.UNKNOWN);
+    assertThat(service.levelOf(0, 0)).isEqualTo(DiskLevel.UNKNOWN);
+    assertThat(DiskLevel.UNKNOWN.isAtLeast(DiskLevel.DEGRADED)).isFalse();
+  }
+}

--- a/opal-core/src/test/java/org/obiba/opal/core/runtime/storage/DefaultDiskSpaceServiceTest.java
+++ b/opal-core/src/test/java/org/obiba/opal/core/runtime/storage/DefaultDiskSpaceServiceTest.java
@@ -26,40 +26,37 @@ public class DefaultDiskSpaceServiceTest {
   public void setUp() {
     service = new DefaultDiskSpaceService();
     // the shipped defaults, so that the test says what an installation actually does
-    ReflectionTestUtils.setField(service, "warnPercent", 15);
     ReflectionTestUtils.setField(service, "warnBytes", 5 * GIB);
-    ReflectionTestUtils.setField(service, "degradedPercent", 5);
-    ReflectionTestUtils.setField(service, "degradedBytes", GIB);
-    ReflectionTestUtils.setField(service, "criticalPercent", 1);
-    ReflectionTestUtils.setField(service, "criticalBytes", 256 * 1024 * 1024L);
-  }
-
-  @Test
-  public void test_a_percentage_and_a_size_whichever_is_larger() {
-    // on a small volume the percentage is meaningless and the absolute floor decides
-    assertThat(service.requiredFreeSpace(20 * GIB, 5, GIB)).isEqualTo(GIB);
-    // on a large one it is the other way round
-    assertThat(service.requiredFreeSpace(1000 * GIB, 5, GIB)).isEqualTo(50 * GIB);
+    ReflectionTestUtils.setField(service, "degradedBytes", 2 * GIB);
+    ReflectionTestUtils.setField(service, "criticalBytes", 512 * 1024 * 1024L);
   }
 
   @Test
   public void test_levels_on_a_small_volume() {
     long total = 20 * GIB;
     assertThat(service.levelOf(total, 10 * GIB)).isEqualTo(DiskLevel.OK);
-    // 15% of 20 GiB is 3 GiB, but the 5 GiB floor is larger
     assertThat(service.levelOf(total, 4 * GIB)).isEqualTo(DiskLevel.WARN);
-    assertThat(service.levelOf(total, 900 * 1024 * 1024L)).isEqualTo(DiskLevel.DEGRADED);
+    assertThat(service.levelOf(total, GIB)).isEqualTo(DiskLevel.DEGRADED);
     assertThat(service.levelOf(total, 100 * 1024 * 1024L)).isEqualTo(DiskLevel.CRITICAL);
   }
 
   @Test
-  public void test_levels_on_a_large_volume() {
-    long total = 10000 * GIB;
-    assertThat(service.levelOf(total, 2000 * GIB)).isEqualTo(DiskLevel.OK);
-    // there the percentages are what decide: 15%, 5% and 1% of 10 TiB
-    assertThat(service.levelOf(total, 1000 * GIB)).isEqualTo(DiskLevel.WARN);
-    assertThat(service.levelOf(total, 300 * GIB)).isEqualTo(DiskLevel.DEGRADED);
-    assertThat(service.levelOf(total, 50 * GIB)).isEqualTo(DiskLevel.CRITICAL);
+  public void test_the_same_free_space_reads_the_same_on_any_volume() {
+    // what a level answers is whether there is room left to work, and that does not depend on how big the disk is.
+    // A percentage got this wrong: 15% of a 468 GB volume asked for 70 GB of headroom nothing would ever use.
+    for(long total : new long[] { 20 * GIB, 468 * GIB, 10000 * GIB }) {
+      assertThat(service.levelOf(total, 10 * GIB)).isEqualTo(DiskLevel.OK);
+      assertThat(service.levelOf(total, 4 * GIB)).isEqualTo(DiskLevel.WARN);
+      assertThat(service.levelOf(total, GIB)).isEqualTo(DiskLevel.DEGRADED);
+      assertThat(service.levelOf(total, 100 * 1024 * 1024L)).isEqualTo(DiskLevel.CRITICAL);
+    }
+  }
+
+  @Test
+  public void test_the_reading_that_started_this() {
+    // 27.64 GB free of 467.89 GB, reported as WARN by the percentage thresholds and four gigabytes away from having
+    // its imports refused, on a volume with ample room to operate
+    assertThat(service.levelOf(467_890_000_000L, 27_640_000_000L)).isEqualTo(DiskLevel.OK);
   }
 
   @Test

--- a/opal-server/src/main/conf/opal-config.properties
+++ b/opal-server/src/main/conf/opal-config.properties
@@ -83,15 +83,13 @@
 # /system/status, and nothing is refused.
 #org.obiba.opal.storage.disk.enforce=false
 
-# Each level is reached when the free space falls under the larger of the percentage and the number of bytes.
+# Each level is reached when the free space falls under the number of bytes. The thresholds are absolute and not a
+# share of the volume, because what has to fit does not grow with the disk.
 # WARN is reported only; at DEGRADED the imports, copies, backups, restores and uploads are refused, while reads,
 # login and configuration writes keep working; at CRITICAL the running tasks are cancelled as well.
-#org.obiba.opal.storage.disk.warn.percent=15
 #org.obiba.opal.storage.disk.warn.bytes=5368709120
-#org.obiba.opal.storage.disk.degraded.percent=5
-#org.obiba.opal.storage.disk.degraded.bytes=1073741824
-#org.obiba.opal.storage.disk.critical.percent=1
-#org.obiba.opal.storage.disk.critical.bytes=268435456
+#org.obiba.opal.storage.disk.degraded.bytes=2147483648
+#org.obiba.opal.storage.disk.critical.bytes=536870912
 
 # How much more room than its announced size an upload is asked to leave
 #org.obiba.opal.storage.disk.upload.safetyFactor=1.2

--- a/opal-server/src/main/conf/opal-config.properties
+++ b/opal-server/src/main/conf/opal-config.properties
@@ -68,6 +68,35 @@
 #org.obiba.opal.cache.variableSummaries=true
 
 ##
+# Storage safeguards
+##
+
+# How often the open H2 databases are forced to physical disk, in milliseconds. While Opal runs, H2 writes pages in
+# the background but never syncs the file, so a power loss costs everything written since the last checkpoint.
+# Set to 0 or less to disable.
+#org.obiba.opal.storage.checkpoint.interval=300000
+
+# How often the free space of the volumes Opal writes to is sampled, in milliseconds (0 or less to disable)
+#org.obiba.opal.storage.disk.interval=60000
+
+# Whether the disk space levels are acted upon. When false the readings are still taken and reported in
+# /system/status, and nothing is refused.
+#org.obiba.opal.storage.disk.enforce=false
+
+# Each level is reached when the free space falls under the larger of the percentage and the number of bytes.
+# WARN is reported only; at DEGRADED the imports, copies, backups, restores and uploads are refused, while reads,
+# login and configuration writes keep working; at CRITICAL the running tasks are cancelled as well.
+#org.obiba.opal.storage.disk.warn.percent=15
+#org.obiba.opal.storage.disk.warn.bytes=5368709120
+#org.obiba.opal.storage.disk.degraded.percent=5
+#org.obiba.opal.storage.disk.degraded.bytes=1073741824
+#org.obiba.opal.storage.disk.critical.percent=1
+#org.obiba.opal.storage.disk.critical.bytes=268435456
+
+# How much more room than its announced size an upload is asked to leave
+#org.obiba.opal.storage.disk.upload.safetyFactor=1.2
+
+##
 # Security settings
 ##
 

--- a/opal-shell/src/main/java/org/obiba/opal/shell/CommandJob.java
+++ b/opal-shell/src/main/java/org/obiba/opal/shell/CommandJob.java
@@ -13,6 +13,8 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.session.Session;
+import org.obiba.opal.core.service.storage.DiskSpaceService;
+import org.obiba.opal.core.service.storage.InsufficientStorageException;
 import org.obiba.opal.shell.commands.Command;
 import org.obiba.opal.shell.commands.CommandResult;
 import org.obiba.opal.shell.commands.ResultCapable;
@@ -72,6 +74,12 @@ public class CommandJob implements OpalShell, Runnable {
   private Long endProgress;
 
   private Integer percentProgress;
+
+  /**
+   * Set when the job is launched, and left null by the callers that build a job by hand. A null one means no check,
+   * which is what keeps the class usable on its own.
+   */
+  private DiskSpaceService diskSpaceService;
 
   //
   // CommandJob
@@ -161,6 +169,14 @@ public class CommandJob implements OpalShell, Runnable {
       if(status != Status.CANCEL_PENDING) {
         status = Status.IN_PROGRESS;
         startTime = getCurrentTime();
+        // Every long running writer - import, copy, backup, restore, VCF export, analysis - passes through here, so
+        // this is where a full disk stops them, once, rather than in each command. It is checked at execution time
+        // and not at submission: a job can sit in its queue for a long while behind another one.
+        if(isRefusedForDiskSpace()) {
+          status = Status.FAILED;
+          printCompletion();
+          return;
+        }
         errorCode = command.execute();
       }
 
@@ -193,6 +209,22 @@ public class CommandJob implements OpalShell, Runnable {
 
   public Command<?> getCommand() {
     return command;
+  }
+
+  public void setDiskSpaceService(DiskSpaceService diskSpaceService) {
+    this.diskSpaceService = diskSpaceService;
+  }
+
+  private boolean isRefusedForDiskSpace() {
+    if(diskSpaceService == null) return false;
+    try {
+      diskSpaceService.checkWritable();
+      return false;
+    } catch(InsufficientStorageException e) {
+      printf("%s", e.getMessage());
+      log.warn("Task {} was not started, there is not enough free disk space: {}", id, e.getMessage());
+      return true;
+    }
   }
 
   public String getOwner() {

--- a/opal-shell/src/main/java/org/obiba/opal/shell/service/impl/DefaultCommandJobService.java
+++ b/opal-shell/src/main/java/org/obiba/opal/shell/service/impl/DefaultCommandJobService.java
@@ -16,17 +16,22 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Maps;
+import com.google.common.eventbus.Subscribe;
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.subject.Subject;
 import org.obiba.opal.core.cfg.OpalConfigurationExtension;
+import org.obiba.opal.core.event.DiskLevelChangedEvent;
 import org.obiba.opal.core.runtime.NoSuchServiceConfigurationException;
 import org.obiba.opal.core.security.SessionDetachedSubject;
+import org.obiba.opal.core.service.storage.DiskLevel;
+import org.obiba.opal.core.service.storage.DiskSpaceService;
 import org.obiba.opal.shell.CommandJob;
 import org.obiba.opal.shell.service.CommandJobService;
 import org.obiba.opal.shell.service.NoSuchCommandJobException;
 import org.obiba.opal.web.model.Commands.CommandStateDto.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
@@ -45,6 +50,9 @@ public class DefaultCommandJobService implements CommandJobService {
   //
 
   private Executor executor;
+
+  @Autowired(required = false)
+  private DiskSpaceService diskSpaceService;
 
   private final Map<String, Executor> projectExecutors;
 
@@ -152,6 +160,7 @@ public class DefaultCommandJobService implements CommandJobService {
     commandJob.setId(nextJobId());
     commandJob.setOwner(owner.getPrincipal().toString());
     commandJob.setSubmitTime(getCurrentTime());
+    commandJob.setDiskSpaceService(diskSpaceService);
 
     if (commandJob.hasProject()) {
       return launchProjectCommand(commandJob, owner);
@@ -250,6 +259,25 @@ public class DefaultCommandJobService implements CommandJobService {
         getTerminatedJobs().remove(futureCommandJob);
         cleanupResult(job);
       }
+    }
+  }
+
+  /**
+   * At {@code CRITICAL} the running writers are stopped as well, and not only the ones that have yet to start. A
+   * cancelled import can be run again once there is room; an MVStore that hits a full disk calls {@code panic()} and
+   * closes without persisting, and that costs a restart and whatever had not been written.
+   */
+  @Subscribe
+  public void onDiskLevelChanged(DiskLevelChangedEvent event) {
+    if(!event.getLevel().isAtLeast(DiskLevel.CRITICAL)) return;
+    if(diskSpaceService == null || !diskSpaceService.isEnforced()) return;
+
+    for(FutureCommandJob futureCommandJob : new ArrayList<>(getStartedJobs())) {
+      CommandJob job = futureCommandJob.getCommandJob();
+      if(job.getStatus() != Status.IN_PROGRESS) continue;
+      log.warn("Cancelling task {}, there is not enough free disk space: {}", job.getId(), event.getDetail());
+      job.setStatus(Status.CANCEL_PENDING);
+      futureCommandJob.cancel(true);
     }
   }
 

--- a/opal-ui/src/components/DiskSpaceBanner.vue
+++ b/opal-ui/src/components/DiskSpaceBanner.vue
@@ -1,0 +1,88 @@
+<template>
+  <q-banner v-if="banner" dense :class="banner.classes" class="q-px-md">
+    <template v-slot:avatar>
+      <q-icon :name="banner.icon" />
+    </template>
+    <div>{{ banner.message }}</div>
+    <div class="text-caption">
+      <span v-for="(disk, idx) in lowDisks" :key="disk.path">
+        <span v-if="idx > 0"> — </span>
+        {{ disk.name }} ({{ disk.path }}): {{ getSizeLabel(disk.usable) }} {{ t('disk_space.free_of') }}
+        {{ getSizeLabel(disk.total) }}
+      </span>
+    </div>
+  </q-banner>
+</template>
+
+<script setup lang="ts">
+import { OpalStatus_DiskLevel } from 'src/models/Opal';
+import type { OpalStatus_DiskUsage } from 'src/models/Opal';
+import { getSizeLabel } from 'src/utils/files';
+
+// The server samples once a minute, so asking more often than that would only report the same number again.
+const REFRESH_INTERVAL = 60000;
+
+const { t } = useI18n();
+const systemStore = useSystemStore();
+const authStore = useAuthStore();
+
+const level = ref<OpalStatus_DiskLevel>(OpalStatus_DiskLevel.UNKNOWN);
+const disks = ref<OpalStatus_DiskUsage[]>([]);
+let timer: ReturnType<typeof setInterval> | undefined;
+
+// UNKNOWN is not the least severe level but outside the scale: a volume that could not be measured is not a reason to
+// tell an administrator anything.
+const lowDisks = computed(() =>
+  disks.value.filter((disk) =>
+    [OpalStatus_DiskLevel.WARN, OpalStatus_DiskLevel.DEGRADED, OpalStatus_DiskLevel.CRITICAL].includes(disk.level),
+  ),
+);
+
+const banner = computed(() => {
+  switch (level.value) {
+    case OpalStatus_DiskLevel.CRITICAL:
+      return {
+        classes: 'bg-negative text-white',
+        icon: 'error',
+        message: t('disk_space.critical'),
+      };
+    case OpalStatus_DiskLevel.DEGRADED:
+      return {
+        classes: 'bg-negative text-white',
+        icon: 'warning',
+        message: t('disk_space.degraded'),
+      };
+    case OpalStatus_DiskLevel.WARN:
+      return {
+        classes: 'bg-warning text-dark',
+        icon: 'warning',
+        message: t('disk_space.warn'),
+      };
+    default:
+      return undefined;
+  }
+});
+
+onMounted(() => {
+  refresh();
+  timer = setInterval(refresh, REFRESH_INTERVAL);
+});
+
+onUnmounted(() => {
+  if (timer) clearInterval(timer);
+});
+
+function refresh() {
+  if (!authStore.isAdministrator) return;
+  systemStore
+    .getStatus()
+    .then((status) => {
+      level.value = status.diskLevel || OpalStatus_DiskLevel.UNKNOWN;
+      disks.value = status.disks || [];
+    })
+    .catch(() => {
+      // the banner is a courtesy, and a failed poll is not worth a notification
+      level.value = OpalStatus_DiskLevel.UNKNOWN;
+    });
+}
+</script>

--- a/opal-ui/src/i18n/en/index.js
+++ b/opal-ui/src/i18n/en/index.js
@@ -131,6 +131,12 @@ export default {
     settings_init_help: 'Select which DataSHIELD packages will get their methods and options applied to this profile.',
     settings_init: 'Initialize the DataSHIELD profile settings with selected DataSHIELD packages',
   },
+  disk_space: {
+    free_of: 'free of',
+    warn: 'Disk space is running low on the Opal server.',
+    degraded: 'Not enough free disk space: imports, copies, backups and uploads are being refused. Free some space to resume them.',
+    critical: 'Critically low disk space: running tasks are being cancelled to keep the databases from failing. Free some space now.',
+  },
   error: {
     Forbidden: 'This operation is forbidden',
     NoSuchValueTableInDatasource: 'The table does not exist or you do not have access to it',

--- a/opal-ui/src/i18n/fr/index.js
+++ b/opal-ui/src/i18n/fr/index.js
@@ -131,6 +131,12 @@ export default {
     settings_init_help: 'Selectionner quels paquets DataSHIELD auront leurs méthodes et options appliqués à ce profil.',
     settings_init: 'Initialiser la configuration DataSHIELD du profil à partir des paquets DataSHIELD sélectionnés',
   },
+  disk_space: {
+    free_of: 'libre sur',
+    warn: "L'espace disque du serveur Opal commence à manquer.",
+    degraded: "Espace disque insuffisant : les importations, copies, sauvegardes et téléversements sont refusés. Libérez de l'espace pour les reprendre.",
+    critical: "Espace disque critique : les tâches en cours sont annulées afin d'éviter une défaillance des bases de données. Libérez de l'espace immédiatement.",
+  },
   error: {
     Forbidden: "L'operation est interdite",
     NoSuchValueTableInDatasource: "La table n'existe pas ou vous n'y avez pas accès",

--- a/opal-ui/src/layouts/MainLayout.vue
+++ b/opal-ui/src/layouts/MainLayout.vue
@@ -107,6 +107,7 @@
     </q-drawer>
 
     <q-page-container>
+      <disk-space-banner />
       <router-view />
       <re-signin-dialog v-model="authStore.reAuthRequired" />
     </q-page-container>
@@ -122,6 +123,7 @@ import ProjectDrawer from 'src/components/ProjectDrawer.vue';
 import FilesDrawer from 'src/components/FilesDrawer.vue';
 import TaxonomiesDrawer from 'src/components/TaxonomiesDrawer.vue';
 import ReSigninDialog from 'src/components/ReSigninDialog.vue';
+import DiskSpaceBanner from 'src/components/DiskSpaceBanner.vue';
 import type { QueryResultDto } from 'src/models/Search';
 import type { ItemFieldsResultDto } from 'src/stores/search';
 

--- a/opal-ui/src/models/Opal.ts
+++ b/opal-ui/src/models/Opal.ts
@@ -329,6 +329,34 @@ export interface OpalStatus {
   nonHeapMemory: OpalStatus_MemoryUsage | undefined;
   threads: OpalStatus_ThreadsUsage | undefined;
   gcs: OpalStatus_GarbageCollectorUsage[];
+  disks: OpalStatus_DiskUsage[];
+  /** the worst of the volumes above */
+  diskLevel?: OpalStatus_DiskLevel | undefined;
+  /** whether that level is acted upon, or only reported */
+  diskEnforced?: boolean | undefined;
+}
+
+/**
+ * How much room is left on a volume Opal writes to. UNKNOWN means the volume could not be measured, and never
+ * blocks anything.
+ */
+export enum OpalStatus_DiskLevel {
+  UNKNOWN = 'UNKNOWN',
+  OK = 'OK',
+  WARN = 'WARN',
+  DEGRADED = 'DEGRADED',
+  CRITICAL = 'CRITICAL',
+  UNRECOGNIZED = 'UNRECOGNIZED',
+}
+
+/** One entry per volume, not per folder: the folders Opal watches are usually on the same mount. */
+export interface OpalStatus_DiskUsage {
+  /** the watched folders on this volume */
+  name: string;
+  path: string;
+  total: number;
+  usable: number;
+  level: OpalStatus_DiskLevel;
 }
 
 /** http://docs.oracle.com/javase/7/docs/api/java/lang/management/MemoryUsage.html */

--- a/opal-ui/src/stores/system.ts
+++ b/opal-ui/src/stores/system.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia';
 import { api } from 'src/boot/api';
 import type { DatabaseDto, DatabasesStatusDto } from 'src/models/Database';
-import type { GeneralConf } from 'src/models/Opal';
+import type { GeneralConf, OpalStatus } from 'src/models/Opal';
 
 export const useSystemStore = defineStore('system', () => {
   const generalConf = ref<GeneralConf>({} as GeneralConf);
@@ -18,6 +18,10 @@ export const useSystemStore = defineStore('system', () => {
 
   async function saveGeneralConf(data: GeneralConf) {
     return api.put('/system/conf/general', data).then(initGeneralConf);
+  }
+
+  async function getStatus(): Promise<OpalStatus> {
+    return api.get('/system/status').then((response) => response.data);
   }
 
   async function getDatabasesStatus(): Promise<DatabasesStatusDto> {
@@ -60,6 +64,7 @@ export const useSystemStore = defineStore('system', () => {
     generalConf,
     initGeneralConf,
     saveGeneralConf,
+    getStatus,
     getDatabasesStatus,
     getDatabases,
     getDatabasesWithSettings,

--- a/opal-web-model/src/main/protobuf/Opal.proto
+++ b/opal-web-model/src/main/protobuf/Opal.proto
@@ -318,12 +318,32 @@ message OpalStatus {
     required int64 collectionCount = 2;
     required int64 collectionTime = 3;
   }
+  // How much room is left on a volume Opal writes to. UNKNOWN means the volume could not be measured, and never
+  // blocks anything.
+  enum DiskLevel {
+    UNKNOWN = 0;
+    OK = 1;
+    WARN = 2;
+    DEGRADED = 3;
+    CRITICAL = 4;
+  }
+  // One entry per volume, not per folder: the folders Opal watches are usually on the same mount.
+  message DiskUsage {
+    required string name = 1; // the watched folders on this volume
+    required string path = 2;
+    required int64 total = 3;
+    required int64 usable = 4;
+    required DiskLevel level = 5;
+  }
   required int64 timestamp = 1;
   required int64 uptime = 2;
   required MemoryUsage heapMemory = 3;
   required MemoryUsage nonHeapMemory = 4;
   required ThreadsUsage threads = 5;
   repeated GarbageCollectorUsage gcs = 6;
+  repeated DiskUsage disks = 7;
+  optional DiskLevel diskLevel = 8; // the worst of the volumes above
+  optional bool diskEnforced = 9; // whether that level is acted upon, or only reported
 }
 
 message GeneralConf {


### PR DESCRIPTION
Closes points 1 and 2 of #4186. Four commits, one per step, reviewable in order.

**1. Reject the H2 settings that would disable the shutdown fsync.** H2 already ends a clean close in `FileChannel.force(true)`, reached both when the last connection is released and from the JVM shutdown hook — so the shutdown checkpoint the issue suggests would be a no-op and is deliberately not implemented. What *is* missing is a guard: `DB_CLOSE_ON_EXIT=FALSE` and a non-zero `DB_CLOSE_DELAY` take that fsync away, and neither is caught by the URL pattern once passed as a connection property.

**2. Watch the free disk space.** When the disk fills, H2 calls `MVStore.panic()` and closes without persisting — no failed statement to retry, no recovery short of a restart — so the check has to be pre-emptive. `DiskSpaceService` samples the data folders, the Opal file system, the logs and the temporary folder once a minute, one reading per volume. Thresholds are the larger of a percentage and an absolute size, since 5% of a 10 TB volume is 500 GB and 5% of a 20 GB volume is 1 GB. An unmeasurable volume is `UNKNOWN` and never blocks anything. Reported in `/system/status` and in a banner in the web interface.

**3. Refuse the large writes before the small ones start failing.** At `DEGRADED` the unbounded, user-initiated, restartable writes are refused while reads, login and configuration writes keep working — that is what leaves an administrator a way in to make room. One gate in `CommandJob.run()` covers every long-running writer; uploads are checked up front against `Content-Length` and refused with 507; at `CRITICAL` running tasks are cancelled too.

**4. Force the open H2 databases to disk periodically.** Nothing else does: `writeInBackground()` only `tryCommit()`s, and `WRITE_DELAY` buys no durability. `CHECKPOINT SYNC` every five minutes on the configuration database and on the storage databases that are *open* — `getLoadedDataSources()` reads the cache without going through its loader, so this does not become "hold a connection pool on every registered database".

### Notes for the reviewer

- **Nothing is enforced by default.** `org.obiba.opal.storage.disk.enforce=false` ships off, so PR2's readings can be tuned against real deployments before PR3 starts failing jobs. Commit 3 is the only user-visible behaviour change.
- **The scheduler is deliberately not a `TaskScheduler` bean.** Declaring one would make it the scheduler for every `@Scheduled` method in Opal, which is the opposite of the isolation wanted.
- `Opal.proto` changes are additive; `opal-ui/src/models/Opal.ts` is generated output edited by hand in the generator's style, as no generation script is in the repo.
- No admin-recipient config key exists, so the optional disk-space email is not implemented; transitions are logged edge-triggered instead.
- `getUsableSpace()` reports host or overlay values inside containers. This is a safety net, not a monitoring system.

Design notes: `obiba-home/docs/opal/2026-08-31-durability-and-disk-space-safeguards.md`.
